### PR TITLE
Longname conflict checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# All compiled Python modules
+*.pyc
+

--- a/schemes/common.py
+++ b/schemes/common.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import subprocess
+
+def execute(cmd, debug = False, abort = True):
+    """Runs a local command in a shell. Waits for completion and
+    returns status, stdout and stderr. If abort = True, abort in
+    case an error occurs during the execution of the command."""
+    
+    debug = True
+    
+    if debug:
+        print 'Executing "{0}"'.format(cmd)
+    p = subprocess.Popen(cmd, stdout = subprocess.PIPE,
+                         stderr = subprocess.PIPE, shell = True)
+    (stdout, stderr) = p.communicate()
+    status = p.returncode
+    if debug:
+        message = 'Execution of "{0}" returned with exit code {1}\n'.format(cmd, status)
+        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        print message
+    if not status == 0:
+        message = 'Execution of command {0} failed, exit code {1}\n'.format(cmd, status)
+        message += '    stdout: "{0}"\n'.format(stdout.rstrip('\n'))
+        message += '    stderr: "{0}"'.format(stderr.rstrip('\n'))
+        if abort:
+            raise Exception(message)
+        else:
+            print message
+    return (status, stdout.rstrip('\n'), stderr.rstrip('\n'))

--- a/schemes/longnames_autocheck.py
+++ b/schemes/longnames_autocheck.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+# Standard modules
+import os
+
+# Local modules
+from common import execute
+from parse_fortran import parse_subroutine_call
+from parse_scheme_table import parse_scheme_tables
+from process_tables import scheme_type, subroutine_type, parse_xml_files, process_arguments, find_longname_conflicts
+
+
+separators = [
+    {
+     'user' : 'christopherwharrop',
+     'branch' : 'harrop_gfs',
+     'files' : ['sfc_nst.f'],
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], # last update 20171114_1036
+     'use_existing' : False,
+    },
+    { 
+     'user' : 'davegill',
+     'branch' : 'gfs_separator_SASS',
+     'files' : ['mfdeepcnv.f'],
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], # last update 20171114_1036
+     'use_existing' : False,
+    },
+    { 
+     'user' : 'grantfirl',
+     'branch' : 'EDMF_table',
+     'files' : ['moninedmf.f', 'GFS_PBL_generic.f90'], # last update 20171114_1036
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'],
+     'use_existing' : False,
+    },
+    {
+     'user' : 'gsketefian',
+     'branch' : 'gsk_separator_work_gfs',
+     'files' : ['gwdc.f', 'gwdps.f', 'rayleigh_damp.f', 'get_prs_fv3.f90', 'get_prs_fv3.f90', 'cnvc90.f', 'dcyc2.f', ], # last update 20171114_1036
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'],
+     'use_existing' : False,
+    },
+    { 
+     'user' : 'JulieSchramm',
+     'branch' : 'gfs_separator_shalcnv',
+     'files' : ['mfshalcnv.f'],
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], # last update 20171114_1036
+     'use_existing' : False,
+    },
+    #{
+    # 'user' : 'kellylittleblackdog',
+    # 'branch' : 'seaice_separator_work_gfs',
+    # 'files' : ['sfc_sice.f'],
+    # 'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], # last update 20171114_1036
+    # 'use_existing' : False,
+    #},
+    {
+     'user' : 'lulinxue',
+     'branch' : 'GFS_separate_Noah_LSM_master_gfsphysics',
+     'files' : ['sfc_drv.f', 'sfc_diff.f', 'sfc_diag.f'], # last update 20171114_1036
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'],
+     'use_existing' : True,
+    },
+    { 
+     'user' : 'mzhangw',
+     'branch' : 'masep',
+     'files' : ['gscond.f', 'precpd.f', 'GFS_calpreciptype.f90', 'GFS_MP_generic_post.f90'], # last update 20171114_1036
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'],
+     'use_existing' : False,
+    },
+    { 
+     'user' : 'pedro-jm',
+     'branch' : 'radiation2',
+     'files' : ['radsw_main.f', 'radlw_main.f'],
+     'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], # last update 20171110 or earlier
+     'use_existing' : True,
+    },
+    #{ 'user' : '', 'branch' : '', 'files' : [''], 'driverfiles' : ['GFS_physics_driver.F90', 'GFS_radiation_driver.F90'], 'use_existing' : False,},
+    ]
+
+SEPARATORS_INFO_HTML_TEMPLATE = """<p><h2>List of separators, branches and files with modifications</h2></p>
+
+<table>
+<tr>
+<th align='left'>Separator</th><th align='left'>Branch</th><th align='left'>Files modified</th>
+</tr>
+{0}
+</table>
+"""
+
+def main():
+    basedir = os.getcwd()
+
+    # For each of the separators, check out the branches listed above
+    calling_var_set = set()
+    all_schemes = []
+    for separator in separators:
+        os.chdir(basedir)
+        user = separator['user']
+        branch = separator['branch']
+        clonedir = '{0}_{1}_gmtb-gfsphysics'.format(user, branch)
+        use_existing = separator['use_existing']
+        if use_existing and not os.path.isdir(clonedir):
+            raise Exception('I was asked to use existing clone directory {0}, but it does not exist.'.format(clonedir))
+        elif not use_existing and os.path.isdir(clonedir):
+            print 'Clone directory {0} already exists, removing it.'.format(clonedir)
+            cmd = 'rm -fr {0}'.format(clonedir)
+            execute(cmd)
+
+        if not use_existing:
+            # Clone repository
+            cmd = 'git clone https://github.com/{0}/gmtb-gfsphysics.git {1}'.format(user, clonedir)
+            execute(cmd)
+            # Checkout branch
+            os.chdir(clonedir)
+            cmd = 'git checkout {0}'.format(branch)
+            execute(cmd, debug = True)
+
+        # It is assumed that all modified files (except the driverfile) reside in subdirectory physics
+        os.chdir(basedir)
+        files = [ os.path.join(clonedir, 'physics', file) for file in separator['files'] ]
+        # Test that all files exists
+        for file in files:
+            if not os.path.isfile(file):
+                raise Exception('Input file {0} for user {1} and branch {2} not found.'.format(file, user, branch))
+        xmlfiles = parse_scheme_tables(files)
+        #print xmlfiles
+        schemes = parse_xml_files(xmlfiles)
+        #print schemes
+
+        for driverfile in separator['driverfiles']:
+            driverfilepath = os.path.join(clonedir, 'GFS_layer', driverfile)
+
+            new_schemes = []
+            for scheme in schemes:
+                new_subroutines = []
+                for subroutine in scheme.subroutines:
+
+                    # Extract the argument list for every call to the routine in the driverfile
+                    calls = parse_subroutine_call(driverfilepath, subroutine.name)
+                    # Warn if function is not called?
+                    if len(calls) == 0:
+                        print "Found no calls to routine {0} in {1}, skip".format(subroutine.name, driverfile)
+                    for call in calls:
+                        print "Parsing call {0}/{1} for routine {2} in {3}".format(calls.index(call)+1, len(calls),
+                                                                                       subroutine.name, driverfile)
+                        new_tuple = subroutine_type(name = subroutine.name, arguments = subroutine.arguments, calling_vars = call)
+                        #(success, subroutine) = process_arguments(new_tuple)
+                        (success, new_subroutine) = process_arguments(new_tuple)
+                        if success:
+                            new_subroutines.append(new_subroutine)
+                            for var in subroutine.arguments:
+                                #only add the calling var to the set if it is not empty
+                                if(var.calling_var):
+                                    calling_var_set.add(var.calling_var)
+
+                new_schemes.append(scheme_type(name=scheme.name, subroutines=new_subroutines))
+            all_schemes += new_schemes
+
+        del schemes
+
+    print
+    print "---"
+    print
+    
+    # Create info on separators as html table
+    html_text = ''
+    for separator in separators:
+        html_text += '<tr><td>{0}</td><td>{1}</td><td>{2}</td></tr>\n'.format(separator['user'],
+                                                                                 separator['branch'],
+                                                                                 ', '.join(separator['files']))
+    separators_info = SEPARATORS_INFO_HTML_TEMPLATE.format(html_text)
+
+    html = find_longname_conflicts(calling_var_set, all_schemes, separators_info)
+    f = open('conflicts.html', 'w')
+    f.write(html)
+    f.close()
+    print 'Write "conflicts.html"'
+
+if __name__ == '__main__':
+    main()

--- a/schemes/parse_fortran.py
+++ b/schemes/parse_fortran.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+def extract_arguments(call):
+    # Replace any leftover multiple whitespaces with single whitespaces
+    call = ' '.join(call.split())
+    # Extract arguments part of call
+    args_start = call.find('(')
+    args_end = call.rfind(')')
+    args_str = (call[args_start+1:args_end]).strip()
+    args_str_formatted = ''
+    # Remove whitespaces from parts of the argument list that are inside brackets
+    # and add missing whitespaces after the comma of each variable in the call
+    open_brackets = 0
+    for i in xrange(len(args_str)):
+        # First check if we are inside or outside of a bracketed area
+        if args_str[i] == '(':
+            open_brackets += 1
+        elif args_str[i] == ')':
+            if open_brackets < 1:
+                raise Exception('Error parsing {0}, found closing bracket w/o matching opening bracket'.format(call))
+            open_brackets -= 1
+        # Remove whitespaces inside bracketed areas
+        if open_brackets > 0 and args_str[i] == ' ':
+            continue
+        args_str_formatted += args_str[i]
+        # Add missing whitespace after comma between arguments
+        if open_brackets == 0 and i<len(args_str)-1 and args_str_formatted[-1] == ',' and not args_str[i+1] == ' ':
+            args_str_formatted += ' '
+    # Split argument list
+    args = [x for x in args_str_formatted.split(', ')]
+    return args
+
+def parse_subroutine_call(file, subroutine):
+    parse = False
+    calls = []
+    with open(file) as f:
+        contents = []
+        for line in f.readlines():
+            line = line.strip()
+            # Skip comments and empty lines
+            if line.startswith('!') or line == '':
+                continue
+            # Replace tabs with single whitespaces
+            line = line.replace('\t', ' ')
+            # Replace multiple whitespaces with one whitespace
+            line = ' '.join(line.split())
+            # Remove inline comments
+            if '!' in line:
+                line = line[:line.find('!')].strip()
+            contents.append(line)
+        for line in contents:
+            #print subroutine + ' : "' + line + '"'
+            if 'call {0}'.format(subroutine) in line.lower():
+            #DH* case sensitive? if 'call {0}'.format(subroutine) in line:
+                parse = True
+                call = line.replace('&', ' ')
+                count_opening_brackets = line.count('(')
+                count_closing_brackets = line.count(')')
+                # Entire call on one line
+                if count_opening_brackets > 0 and count_closing_brackets == count_opening_brackets:
+                    parse = False
+                    arguments = extract_arguments(call)
+                    calls.append(arguments)
+            elif parse:
+                call += line.replace('&', ' ')
+                count_opening_brackets += line.count('(')
+                count_closing_brackets += line.count(')')
+                # Call over multiple lines
+                if count_closing_brackets == count_opening_brackets:
+                    parse = False
+                    arguments = extract_arguments(call)
+                    calls.append(arguments)
+    #print "file, subroutine, calls:", file, subroutine, calls, [len(arguments) for arguments in calls]
+    return calls

--- a/schemes/parse_scheme_table.py
+++ b/schemes/parse_scheme_table.py
@@ -44,147 +44,179 @@ parser = argparse.ArgumentParser()
 parser.add_argument('file', help='paths to fortran source code to parse for generating CCPP scheme XML files', nargs='*')
 args = parser.parse_args()
 
-#for each filename provided, parse it and output one XML file
-for i in range(len(args.file)):
-    filename = args.file[i]
+def parse_scheme_tables(files):
+    xmlfiles = []
+    #for each filename provided, parse it and output one XML file
+    for i in range(len(files)):
+        filename = files[i]
 
-    #read all lines of the file at once
-    with (open(filename, 'r')) as file:
-        file_lines = file.readlines()
+        #read all lines of the file at once
+        with (open(filename, 'r')) as file:
+            file_lines = file.readlines()
 
-    #find all modules within the file, and save the start and end lines
-    module_names = []
-    mod_begin_lines = []
-    mod_end_lines = []
-    line_counter = 0
-    for line in file_lines:
-        words = line.split()
-        for j in range(len(words)):
-            #check for the word 'module', that it is the first word in the line, and that a module name exists afterward
-            if words[j].lower() == 'module' and j+1 <= len(words)-1 and j == 0:
-                mod_begin_lines.append(line_counter)
-                module_names.append(words[j+1].lower().strip())
-        if line.lower().find('end module') >= 0:
-            mod_end_lines.append(line_counter)
-        line_counter += 1
-
-
-    #for each module within the file, create a separate XML file for the "scheme"
-    for l in range(len(module_names)):
-        #find the *_init, *_run, *_finalize, etc. subroutines, save their location within the file and their names
+        #find all modules within the file, and save the start and end lines
+        module_names = []
+        mod_begin_lines = []
+        mod_end_lines = []
         line_counter = 0
-        sub_lines = []
-        sub_names = []
-        scheme_names = []
-        #only look at the lines in the current module
-        for line in file_lines[mod_begin_lines[l]:mod_end_lines[l]]:
+        for line in file_lines:
             words = line.split()
             for j in range(len(words)):
-                #check for the word 'subroutine', that it is the first word in the line, and that a subroutine name exists afterward
-                if words[j].lower() == 'subroutine' and j+1 <= len(words)-1 and j == 0:
-                    #consider the last substring separated by a '_' of the subroutine name as a 'postfix'
-                    sub_name = words[j+1].split('(')[0].strip()
-                    if sub_name.find('_') >= 0:
-                        #ignore subroutines that have no postfix
-                        if sub_name.find('init') >= 0 or sub_name.find('run') >= 0 or sub_name.find('finalize') >= 0:
-                            #ignore subroutines that have postfixes other than init, run, finalize
-                            sub_lines.append(line_counter)
-                            sub_names.append(sub_name.lower())
-                            scheme_names.append(sub_names[-1][0:sub_names[-1].rfind('_')])
+                #check for the word 'module', that it is the first word in the line, and that a module name exists afterward
+                if words[j].lower() == 'module' and j+1 <= len(words)-1 and j == 0:
+                    mod_begin_lines.append(line_counter)
+                    module_names.append(words[j+1].lower().strip())
+            if line.lower().find('end module') >= 0:
+                mod_end_lines.append(line_counter)
             line_counter += 1
 
-        #check that all the subroutine "root" names in the current module are the same
-        if scheme_names.count(scheme_names[0]) == len(scheme_names):
-            scheme_name = scheme_names[0]
-        else:
-            print 'Please check that all of the subroutines have the same root name: i.e. scheme_A_init, scheme_A_run, scheme_A_finalize'
-            print 'Here is a list of the subroutine names:'
-            print sub_names
-            print 'Here is a list of the scheme names (parsed from the subroutine names):'
-            print scheme_names
-            quit()
 
-
-        table_header_sets = []
-        var_data_sets = []
-        for j in range(len(sub_names)):
-            #find the argument table corresponding to each subroutine by searching "upward" from the subroutine definition line for the "arg_table_SubroutineName" section
-            table_found = False
-            for k in range(mod_begin_lines[l] + sub_lines[j], -1, -1):
-                line = file_lines[k]
+        #for each module within the file, create a separate XML file for the "scheme"
+        for l in range(len(module_names)):
+            #find the *_init, *_run, *_finalize, etc. subroutines, save their location within the file and their names
+            line_counter = 0
+            sub_lines = []
+            sub_names = []
+            scheme_names = []
+            #only look at the lines in the current module
+            for line in file_lines[mod_begin_lines[l]:mod_end_lines[l]]:
                 words = line.split()
-                for word in words:
-                    if 'arg_table_' + sub_names[j] in word.lower():
-                        table_found = True
-                        header_line = k + 1
-                        break
-                if table_found:
-                    break
+                for j in range(len(words)):
+                    #check for the word 'subroutine', that it is the first word in the line, and that a subroutine name exists afterward
+                    if words[j].lower() == 'subroutine' and j+1 <= len(words)-1 and j == 0:
+                        #consider the last substring separated by a '_' of the subroutine name as a 'postfix'
+                        sub_name = words[j+1].split('(')[0].strip()
+                        if sub_name.find('_') >= 0:
+                            #ignore subroutines that have no postfix
+                            if sub_name.find('init') >= 0 or sub_name.find('run') >= 0 or sub_name.find('finalize') >= 0:
+                                #ignore subroutines that have postfixes other than init, run, finalize
+                                sub_lines.append(line_counter)
+                                #DH* case sensitive? sub_names.append(sub_name)
+                                sub_names.append(sub_name.lower())
+                                scheme_names.append(sub_names[-1][0:sub_names[-1].rfind('_')])
+                line_counter += 1
 
-            #if an argument table is found, parse it
-            if table_found:
-                #separate the table headers
-                table_headers = file_lines[header_line].split('|')
-                #check for blank table
-                if(len(table_headers) > 1):
-                    table_headers = table_headers[1:-1]
-                    table_header_sets.append([x.strip() for x in table_headers])
 
-                    #get all of the variable information
-                    end_of_table = False
-                    k = header_line + 2
-                    var_data = []
-                    while not end_of_table:
-                        line = file_lines[k]
-                        words = line.split()
-                        if len(words) == 1:
-                            end_of_table = True
-                        else:
-                            var_items = line.split('|')[1:-1]
-                            var_items = [x.strip() for x in var_items]
-                            var_data.append(var_items)
-                        k += 1
-                    var_data_sets.append(var_data)
-                else:
-                    table_header_sets.append([])
-                    var_data_sets.append([])
+            #check that all the subroutine "root" names in the current module are the same
+            if scheme_names.count(scheme_names[0]) == len(scheme_names):
+                scheme_name = scheme_names[0]
             else:
-                #if not table is found, just append an empty list
-               table_header_sets.append([])
-               var_data_sets.append([])
+                message = 'Please check that all of the subroutines have the same root name:\n'
+                message += '    i.e. scheme_A_init, scheme_A_run, scheme_A_finalize\n'
+                message += 'Here is a list of the subroutine names:\n'
+                message += str(sub_names) + '\n'
+                message += 'Here is a list of the scheme names (parsed from the subroutine names):\n'
+                message += str(scheme_names)
+                raise Exception(message)
 
-        #write out the XML in the format that mkcap wants
-        top = ET.Element('scheme')
-        top.set('module', scheme_name)
-        for j in range(len(sub_names)):
-            sub_sub = ET.SubElement(top, 'subroutine')
-            sub_sub.set('name', sub_names[j])
 
-            #right now, the mapping from the tables to the XML is 'local var name' => id, 'longname' => name, units => units, rank => rank, type => type, description => description, kind => kind, intent => intent, optional => optional
-            #### this can be generalized and updated in the future using the table header information ####
-            if len(var_data_sets[j]) > 0:
-                for k in range(len(var_data_sets[j])):
-                    sub_var = ET.SubElement(sub_sub, 'var')
-                    var_name = ET.SubElement(sub_var, 'name')
-                    var_name.text = var_data_sets[j][k][1]
-                    var_units = ET.SubElement(sub_var, 'units')
-                    var_units.text = var_data_sets[j][k][3]
-                    var_id = ET.SubElement(sub_var, 'id')
-                    var_id.text = var_data_sets[j][k][0]
-                    var_rank = ET.SubElement(sub_var, 'rank')
-                    var_rank.text = var_data_sets[j][k][4]
-                    var_type = ET.SubElement(sub_var, 'type')
-                    var_type.text = var_data_sets[j][k][5]
-                    var_description = ET.SubElement(sub_var, 'description')
-                    var_description.text = var_data_sets[j][k][2]
-                    var_kind = ET.SubElement(sub_var, 'kind')
-                    var_kind.text = var_data_sets[j][k][6]
-                    var_intent = ET.SubElement(sub_var, 'intent')
-                    var_intent.text = var_data_sets[j][k][7]
-                    var_optional = ET.SubElement(sub_var, 'optional')
-                    var_optional.text = var_data_sets[j][k][8]
+            table_header_sets = []
+            var_data_sets = []
+            for j in range(len(sub_names)):
+                #find the argument table corresponding to each subroutine by searching
+                #"upward" from the subroutine definition line for the "arg_table_SubroutineName" section
+                table_found = False
+                for k in range(mod_begin_lines[l] + sub_lines[j], -1, -1):
+                    line = file_lines[k]
+                    words = line.split()
+                    for word in words:
+                        if 'arg_table_' + sub_names[j] in word.lower():
+                        # DH* case sensitive? if 'arg_table_' + sub_names[j] in word:
+                            table_found = True
+                            header_line = k + 1
+                            break
+                    if table_found:
+                        break
 
-        indent(top)
-        tree = ET.ElementTree(top)
-        tree.write(scheme_name + '.xml', xml_declaration=True, encoding='utf-8', method="xml")
-        print 'Parsed tables for ' + ", ".join([str(x) for x in sub_names] ) + ' in module ' + module_names[l] + '; output => ' + scheme_name + '.xml'
+                #if an argument table is found, parse it
+                if table_found:
+                    #separate the table headers
+                    table_headers = file_lines[header_line].split('|')
+                    #check for blank table
+                    if(len(table_headers) > 1):
+                        table_headers = table_headers[1:-1]
+                        table_header_sets.append([x.strip() for x in table_headers])
+
+                        #get all of the variable information
+                        end_of_table = False
+                        k = header_line + 2
+                        var_data = []
+                        while not end_of_table:
+                            line = file_lines[k]
+                            words = line.split()
+                            if len(words) == 1:
+                                end_of_table = True
+                            else:
+                                var_items = line.split('|')[1:-1]
+                                var_items = [x.strip() for x in var_items]
+                                var_data.append(var_items)
+                            k += 1
+                        var_data_sets.append(var_data)
+                    else:
+                        table_header_sets.append([])
+                        var_data_sets.append([])
+                else:
+                    #if no table is found, just append an empty list
+                   table_header_sets.append([])
+                   var_data_sets.append([])
+
+            #write out the XML in the format that mkcap wants
+            top = ET.Element('scheme')
+            top.set('module', scheme_name)
+            for j in range(len(sub_names)):
+                sub_sub = ET.SubElement(top, 'subroutine')
+                sub_sub.set('name', sub_names[j])
+
+                #right now, the mapping from the tables to the XML is
+                #   'local var name' => id, 'longname' => name,
+                #   units => units, rank => rank, type => type,
+                #   description => description, kind => kind,
+                #   intent => intent, optional => optional
+                #this can be generalized and updated in the future using the table header information ####
+                if len(var_data_sets[j]) > 0:
+                    for k in range(len(var_data_sets[j])):
+                        sub_var = ET.SubElement(sub_sub, 'var')
+                        var_name = ET.SubElement(sub_var, 'name')
+                        try:
+                            var_name.text = var_data_sets[j][k][1]
+                        except IndexError:
+                            raise IndexError('This can be caused by the argument table missing an empty (!!) line')
+                        var_units = ET.SubElement(sub_var, 'units')
+                        var_units.text = var_data_sets[j][k][3]
+                        var_id = ET.SubElement(sub_var, 'id')
+                        var_id.text = var_data_sets[j][k][0]
+                        var_rank = ET.SubElement(sub_var, 'rank')
+                        var_rank.text = var_data_sets[j][k][4]
+                        var_type = ET.SubElement(sub_var, 'type')
+                        var_type.text = var_data_sets[j][k][5]
+                        var_description = ET.SubElement(sub_var, 'description')
+                        var_description.text = var_data_sets[j][k][2]
+                        var_kind = ET.SubElement(sub_var, 'kind')
+                        var_kind.text = var_data_sets[j][k][6]
+                        var_intent = ET.SubElement(sub_var, 'intent')
+                        var_intent.text = var_data_sets[j][k][7]
+                        var_optional = ET.SubElement(sub_var, 'optional')
+                        var_optional.text = var_data_sets[j][k][8]
+
+            indent(top)
+            tree = ET.ElementTree(top)
+            xmlfile = scheme_name + '.xml'
+            tree.write(xmlfile, xml_declaration=True, encoding='utf-8', method="xml")
+            print 'Parsed tables for ' + ", ".join([str(x) for x in sub_names] ) + ' in module ' \
+                                                      + module_names[l] + '; output => ' + xmlfile
+            xmlfiles.append(xmlfile)
+    return xmlfiles
+
+def main():
+    #set up the command line argument parser
+    parser = argparse.ArgumentParser()
+
+    #the only arguments are a list of filenames to parse
+    parser.add_argument('file', help='paths to fortran source code to parse for generating CCPP scheme XML files', nargs='*')
+    args = parser.parse_args()
+
+    #parse scheme tables in all files
+    parse_scheme_tables(args.file)
+
+if __name__ == '__main__':
+    main()

--- a/schemes/process_tables.py
+++ b/schemes/process_tables.py
@@ -12,175 +12,357 @@
 
 
 import argparse  #needed for command line argument filenames
-from xml.etree import ElementTree as ET #needed for reading XML
 import collections
-
-#set up the command line argument parser
-parser = argparse.ArgumentParser()
-
-#the only arguments are a a list of XML files to parse and a list of files with the subroutine calls
-parser.add_argument('file', help='paths to XML files generated from scheme tables', nargs='*')
-parser.add_argument('--call_file', nargs = '*', action='store', help = 'paths to fortran files that call the schemes')
-#parser.add_argument('call_file', help='paths to fortran files that call the schemes', nargs='1' )
-args = parser.parse_args()
+import datetime
+from xml.etree import ElementTree as ET #needed for reading XML
 
 #set up named tuple types
 var_metadata_type = collections.namedtuple('var_metadata_type', 'longname units id rank type description kind intent optional calling_var')
 scheme_type = collections.namedtuple('scheme_type', 'name subroutines')
 subroutine_type = collections.namedtuple('subroutine_type', 'name arguments calling_vars') #
 
-#each XML file represents one scheme; read in the argument table information from each file
-schemes = []
-for i in range(len(args.file)):
-    filename = args.file[i]
+#for formatted html output
+HTML_DATA_TOP = """<html>
+<head>
+    <title>GMTB separators - longname conflicts</title>
+</head>
+<body>
+<p><h1>GMTB separators - longname conflicts</h1>
+Last update {0}</p>
 
-    tree = ET.parse(filename)
-    scheme = tree.getroot()
+{1}
 
-    #multiple subroutines can be associated with each scheme; XML children of each "scheme" are the subroutines
-    subroutines = []
-    for sub in scheme:
-        vars = []
-        #XML children of each subroutine are the variable metadata
-        for var in sub:
-            #get the metadata from the XML fields
-            longname = var[0].text
-            units = var[1].text
-            id = var[2].text
-            rank = var[3].text
-            type = var[4].text
-            description = var[5].text
-            kind = var[6].text
-            intent = var[7].text
-            optional = var[8].text
-            #create a var_metadata_type with the variable metadata, leaving the calling var field blank at this point (will be filled in using the subroutine call information)
-            var_metadata = var_metadata_type(longname=longname, units=units, id=id, rank=rank, type=type, description=description, kind=kind, intent=intent, optional=optional, calling_var='')
-            #put all var_metadata_types into a vars list
-            vars.append(var_metadata)
-        #append each subroutine_type to a list of subroutines
-        subroutines.append(subroutine_type(name = sub.attrib['name'], arguments = vars, calling_vars = []))
-    #append each scheme_type to a list of schemes
-    schemes.append(scheme_type(name=scheme.attrib['module'], subroutines=subroutines))
+<p><h2>List of schemes and subroutines</h2></p>
 
-#for each file that contains calling information, read the calling argument variables and associate them with a subroutine
-for i in range(len(args.call_file)):
-    filename = args.call_file[i]
+<table rows="2" border="0">
+<tr>
+    <th align="left">Scheme name</th>
+    <th align="left">Subroutines</th>
+</tr>
+{2}
+</table>
 
-    #read all lines of the file at once
-    with (open(filename, 'r')) as file:
-        file_lines = file.readlines()
+"""
 
-    #look for all of the schemes and subroutine calls in this file
+HTML_DATA_MIDDLE ="""<p><h2>List of calling variables</h2></p>
+
+<table rows="2" border="0">
+<tr>
+    <th align="left">Calling variable name</th>
+    <th align="left">Called by</th>
+    <th align="left">Longnames used</th>
+</tr>
+{0}
+</table>
+
+<p><h3>{1}</h3></p>
+
+"""
+
+HTML_DATA_BOTTOM_NO_CONFLICTS = """</body>
+</html>
+"""
+
+HTML_DATA_BOTTOM_CONFLICTS = """<p><h2>Conflicts</h2></p>
+
+<table rows="6" border="0">
+<tr>
+    <th align="left">Calling variable name</th>
+    <th align="left">Long name</th>
+    <th align="left">Local variable name</th>
+    <th align="left">Subroutine</th>
+</tr>
+{0}
+</table>
+</body>
+</html>
+"""
+
+def parse_xml_files(files):
+    #each XML file represents one scheme; read in the argument table information from each file
+    schemes = []
+    for i in range(len(files)):
+        filename = files[i]
+
+        tree = ET.parse(filename)
+        scheme = tree.getroot()
+
+        #multiple subroutines can be associated with each scheme; XML children of each "scheme" are the subroutines
+        subroutines = []
+        for sub in scheme:
+            vars = []
+            #XML children of each subroutine are the variable metadata
+            for var in sub:
+                #get the metadata from the XML fields
+                longname = var[0].text
+                units = var[1].text
+                id = var[2].text
+                rank = var[3].text
+                type = var[4].text
+                #the following attributes are optional
+                try:
+                    description = var[5].text
+                except IndexError:
+                    description = 'missing'
+                try:
+                    kind = var[6].text
+                except IndexError:
+                    kind = 'missing'
+                try:
+                    intent = var[7].text
+                except IndexError:
+                    intent = 'missing'
+                try:
+                    optional = var[8].text
+                except IndexError:
+                    optional = 'missing'
+                #create a var_metadata_type with the variable metadata, leaving the calling var field blank at this point (will be filled in using the subroutine call information)
+                var_metadata = var_metadata_type(longname=longname,
+                                                 units=units,
+                                                 id=id,
+                                                 rank=rank,
+                                                 type=type,
+                                                 description=description,
+                                                 kind=kind,
+                                                 intent=intent,
+                                                 optional=optional,
+                                                 calling_var='')
+                #put all var_metadata_types into a vars list
+                vars.append(var_metadata)
+            #append each subroutine_type to a list of subroutines
+            subroutines.append(subroutine_type(name = sub.attrib['name'], arguments = vars, calling_vars = []))
+        #append each scheme_type to a list of schemes
+        schemes.append(scheme_type(name=scheme.attrib['module'], subroutines=subroutines))
+    return schemes
+
+def process_arguments(subroutine):
+    # Flag indicating success or failure
+    success = True
+
+    #determine how many non-optional arguments are in the subroutine
+    num_non_optional_arguments = 0
+    for k in range(len(subroutine.arguments)):
+        if not (subroutine.arguments[k].optional.lower() == 't' or subroutine.arguments[k].optional.lower() == 'true'):
+            num_non_optional_arguments += 1
+    #num_optional_arguments = (len(subroutine.arguments)) - num_non_optional_arguments
+    
+    if len(subroutine.calling_vars) < num_non_optional_arguments:
+        #if the number of calling argument variables are less than the number of non-optional arguments, let the user know that there is a problem
+        message = 'Too few arguments were supplied in the call to {0}\n'.format(subroutine.name)
+        message += 'calling arguments: {0}\n'.format(len(subroutine.calling_vars))
+        message += 'non-optional subroutine arguments: {0}\n'.format(num_non_optional_arguments)
+        message += '{0}'.format(subroutine.arguments)
+        print 'WARNING: {0} - IGNORING SUBROUTINE'.format(message)
+        success = False
+        #raise Exception(message)
+    elif len(subroutine.calling_vars) == num_non_optional_arguments:
+        #if the number of calling arguments is the same as the number of non-optional arguments, assume that the arguments are positionally correct and assign the calling variables to the subroutine arguments by ORDER
+        for k in range(len(subroutine.arguments)):
+            new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname,
+                                          units=subroutine.arguments[k].units,
+                                          id=subroutine.arguments[k].id,
+                                          rank=subroutine.arguments[k].rank,
+                                          type=subroutine.arguments[k].type,
+                                          description=subroutine.arguments[k].description,
+                                          kind=subroutine.arguments[k].kind,
+                                          intent=subroutine.arguments[k].intent,
+                                          optional=subroutine.arguments[k].optional,
+                                          calling_var=subroutine.calling_vars[k])
+            subroutine.arguments[k] = new_tuple
+    elif len(subroutine.calling_vars) > len(subroutine.arguments):
+        #if there are more calling argument variables supplied than the subroutine expects, let the user know
+        message = 'Too many arguments (mandatory + optional) were supplied in the call to {0}\n'.format(subroutine.name)
+        message += 'calling arguments: {0}\n'.format(len(subroutine.calling_vars))
+        message += 'subroutine arguments: {0}'.format(len(subroutine.arguments))
+        print 'WARNING: {0} - IGNORING SUBROUTINE'.format(message)
+        success = False
+        #raise Exception(message)
+    else:
+        #the number of arguments supplied in the call is greater than the number of non-optional arguments but less than the total of non-optional and optional arguments expected by the subroutine; check for optional arguments
+        for k in range(len(subroutine.arguments)):
+            if subroutine.arguments[k].optional.lower() == 't' or subroutine.arguments[k].optional.lower() == 'true':
+                #for optional arguments, look for arguments being passed in with keywords by id; if the id is not found in the calling variables, then optional_calling_var is an empty list
+                optional_calling_var = [s for s in subroutine.calling_vars if subroutine.arguments[k].id in s]
+                if optional_calling_var:
+                    optional_calling_var = optional_calling_var[0].split('=')[1]
+                    new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname,
+                                                  units=subroutine.arguments[k].units,
+                                                  id=subroutine.arguments[k].id,
+                                                  rank=subroutine.arguments[k].rank,
+                                                  type=subroutine.arguments[k].type,
+                                                  description=subroutine.arguments[k].description,
+                                                  kind=subroutine.arguments[k].kind,
+                                                  intent=subroutine.arguments[k].intent,
+                                                  optional=subroutine.arguments[k].optional,
+                                                  calling_var=optional_calling_var)
+                    subroutine.arguments[k] = new_tuple
+            else:
+                new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname,
+                                              units=subroutine.arguments[k].units,
+                                              id=subroutine.arguments[k].id,
+                                              rank=subroutine.arguments[k].rank,
+                                              type=subroutine.arguments[k].type,
+                                              description=subroutine.arguments[k].description,
+                                              kind=subroutine.arguments[k].kind,
+                                              intent=subroutine.arguments[k].intent,
+                                              optional=subroutine.arguments[k].optional,
+                                              calling_var=subroutine.calling_vars[k])
+                subroutine.arguments[k] = new_tuple
+    return (success, subroutine)
+
+def find_longname_conflicts(calling_var_set, schemes, separators_info = ''):
+    longname_conflicts = []
+    longname_success = []
+
+    print "Parsed schemes and subroutines:"
+    schemes_parsed = {}
     for scheme in schemes:
+        if not scheme.name in schemes_parsed.keys():
+            schemes_parsed[scheme.name] = []
         for subroutine in scheme.subroutines:
-            sub_found = False
-            line_counter = 0
-            for line in file_lines:
-                if line.lower().find(subroutine.name) >= 0:
-                    words = line.split()
-                    for j in range(len(words)):
-                        #search for the subroutine name and that where the subroutine name is found has the structure "call subroutine_name"
-                        if words[j].lower() == subroutine.name and j == 1 and words[j-1].lower() == 'call':
-                            sub_found = True
-                            print subroutine.name + ' found in file ' + filename + ' at line ' + str(line_counter+1)
-                            #grab all the text between the opening and closing () !!!!This section could be made much more robust and be utilized to read the actual fortran files !!!!
-                            args_start = line.find('(')
-                            args_end = line.rfind(')')
-                            args_str = line[args_start+1:args_end]
-                            #divide the string by ', ' (not by ',' alone due to commas in array slice syntax - NOTE: this means that the calling syntax should have all variables separated by ', ' and that all array slices don't have whitespace)
-                            args = [x.strip(' ') for x in args_str.split(', ')]
+            schemes_parsed[scheme.name].append(subroutine.name)
+        schemes_parsed[scheme.name] = sorted(list(set(schemes_parsed[scheme.name])))
+        print scheme.name, ":", schemes_parsed[scheme.name]
 
-                            #since tuples are immutable, create a new one and replace the old one with the calling argument variable information
-                            new_tuple = subroutine_type(name = subroutine.name, arguments = subroutine.arguments, calling_vars = args)
-                            subroutine = new_tuple
+    # Create first part of html output
+    now = datetime.datetime.utcnow()
+    html_text = ''
+    for scheme_name in sorted(schemes_parsed.keys()):
+        html_text += '<tr><td>{0}</td><td>{1}</td></tr>\n'.format(scheme_name, ', '.join(schemes_parsed[scheme_name]))
+    html = HTML_DATA_TOP.format(now.strftime('%Y-%m-%d %H:%M UTC'), separators_info, html_text)
+
+    print "Calling vars:"
+    html_text = ''
+    for calling_var in sorted(calling_var_set):
+        #process each calling variable in the set by searching through the schemes / subroutines for where the calling variable is used, saving the calling var, longname, local_name, and subroutine_name for each time a calling variable is used.
+
+        calling_vars = []
+        longnames = []
+        local_names = []
+        subroutine_names = []
+        for scheme in schemes:
+            for subroutine in scheme.subroutines:
+                for var in subroutine.arguments:
+                    if var.calling_var == calling_var:
+                        calling_vars.append(calling_var)
+                        longnames.append(var.longname)
+                        local_names.append(var.id)
+                        subroutine_names.append(subroutine.name)
+
+        if not longnames:
+            continue
+
+        #check for conflicts; a conflict is when not all longnames used for each calling variable match exactly
+        if longnames.count(longnames[0]) == len(longnames):
+            success = True
+            longname_success.append((calling_vars, longnames, local_names, subroutine_names))
+        else:
+            success = False
+            longname_conflicts.append((calling_vars, longnames, local_names, subroutine_names))
+
+        #print the list of all calling variables and where they are being used
+        print calling_var, subroutine_names, sorted(list(set(longnames)))
+        if success:
+            html_text += '<tr><td>{0}</td><td>{1}</td><td>{2}</td></tr>\n'.format(calling_var,
+                                               ', '.join(sorted(list(set(subroutine_names)))),
+                                                      ', '.join(sorted(list(set(longnames)))))
+        else:
+            html_text += '<tr><td>{0}</td><td>{1}</td><td><font color="red">{2}</font></td></tr>\n'.format(calling_var,
+                                                                        ', '.join(sorted(list(set(subroutine_names)))),
+                                                                               ', '.join(sorted(list(set(longnames)))))
+
+    #print the conflicts (or success)
+    if len(longname_success) == len(calling_var_set):
+        message = '100% success!'
+        print message
+        # Create second part of html output
+        html += HTML_DATA_MIDDLE.format(html_text, message)
+        # Create third part of html output (empty, no conflicts)
+        html += HTML_DATA_BOTTOM_NO_CONFLICTS
+    else:
+        message = '{0} conflicts were found out of {1} possible comparisons!'.format(
+                                       len(longname_conflicts), len(calling_var_set))
+        print message
+        # Create second part of html output
+        html += HTML_DATA_MIDDLE.format(html_text, message)
+        print 'Conflicts:'
+        # Create third part of html output (populated, conflicts)
+        html_text = ''
+        for conflict in longname_conflicts:
+            for i in range(len(conflict[0])):
+                print conflict[0][i], conflict[1][i], conflict[2][i], conflict[3][i]
+                html_text += '<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td></tr>\n'.format(
+                                   conflict[0][i], conflict[1][i], conflict[2][i], conflict[3][i])
+            print # blank line
+            html_text += '<tr><td colspan="4"></td></tr>\n'
+        html += HTML_DATA_BOTTOM_CONFLICTS.format(html_text)
+    return html
+
+def main():
+    #set up the command line argument parser
+    parser = argparse.ArgumentParser()
+
+    #the only arguments are a a list of XML files to parse and a list of files with the subroutine calls
+    parser.add_argument('file', help='paths to XML files generated from scheme tables', nargs='*')
+    parser.add_argument('--call_file', nargs = '*', action='store', help = 'paths to fortran files that call the schemes')
+    #parser.add_argument('call_file', help='paths to fortran files that call the schemes', nargs='1' )
+    args = parser.parse_args()
+
+    schemes = parse_xml_files(args.file)
+
+    #for each file that contains calling information, read the calling argument variables and associate them with a subroutine
+    for i in range(len(args.call_file)):
+        filename = args.call_file[i]
+
+        #read all lines of the file at once
+        with (open(filename, 'r')) as file:
+            file_lines = file.readlines()
+
+        #look for all of the schemes and subroutine calls in this file
+        for scheme in schemes:
+            for subroutine in scheme.subroutines:
+                sub_found = False
+                line_counter = 0
+                for line in file_lines:
+                    if line.lower().find(subroutine.name) >= 0:
+                        words = line.split()
+                        for j in range(len(words)):
+                            #search for the subroutine name and that where the subroutine name is found has the structure "call subroutine_name"
+                            if words[j].lower() == subroutine.name and j == 1 and words[j-1].lower() == 'call':
+                                sub_found = True
+                                print subroutine.name + ' found in file ' + filename + ' at line ' + str(line_counter+1)
+                                #grab all the text between the opening and closing () !!!!This section could be made much more robust and be utilized to read the actual fortran files !!!!
+                                args_start = line.find('(')
+                                args_end = line.rfind(')')
+                                args_str = line[args_start+1:args_end]
+                                #divide the string by ', ' (not by ',' alone due to commas in array slice syntax - NOTE: this means that the calling syntax should have all variables separated by ', ' and that all array slices don't have whitespace)
+                                args = [x.strip(' ') for x in args_str.split(', ')]
+
+                                #since tuples are immutable, create a new one and replace the old one with the calling argument variable information
+                                new_tuple = subroutine_type(name = subroutine.name,
+                                                            arguments = subroutine.arguments,
+                                                            calling_vars = args)
+                                subroutine = new_tuple
 
 
-                        if sub_found:
-                            break
-                line_counter += 1
+                            if sub_found:
+                                break
+                    line_counter += 1
 
-            if sub_found:
-                #determine how many non-optional arguments are in the subroutine
-                num_non_optional_arguments = 0
-                for k in range(len(subroutine.arguments)):
-                    if not (subroutine.arguments[k].optional.lower() == 't' or subroutine.arguments[k].optional.lower() == 'true'):
-                        num_non_optional_arguments += 1
-                #num_optional_arguments = (len(subroutine.arguments)) - num_non_optional_arguments
+                if sub_found:
+                    (success, subroutine) = process_arguments(subroutine)
+                    if not success:
+                        del subroutine
 
-                if len(subroutine.calling_vars) < num_non_optional_arguments:
-                    #if the number of calling argument variables are less than the number of non-optional arguments, let the user know that there is a problem
-                    print 'Too few arguments were supplied in the call to ' + subroutine.name
-                    print 'calling arguments: ' + str(len(subroutine.calling_vars))
-                    print 'non-optional subroutine arguments: ' + str(num_non_optional_arguments)
-                    print subroutine.arguments
-                elif len(subroutine.calling_vars) == num_non_optional_arguments:
-                    #if the number of calling arguments is the same as the number of non-optional arguments, assume that the arguments are positionally correct and assign the calling variables to the subroutine arguments by ORDER
-                    for k in range(len(subroutine.arguments)):
-                        new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname, units=subroutine.arguments[k].units, id=subroutine.arguments[k].id, rank=subroutine.arguments[k].rank, type=subroutine.arguments[k].type, description=subroutine.arguments[k].description, kind=subroutine.arguments[k].kind, intent=subroutine.arguments[k].intent, optional=subroutine.arguments[k].optional, calling_var=subroutine.calling_vars[k])
-                        subroutine.arguments[k] = new_tuple
-                elif len(subroutine.calling_vars) > len(subroutine.arguments):
-                    #if there are more calling argument variables supplied than the subroutine expects, let the user know
-                    print 'Too many arguments (mandatory + optional) were supplied in the call to ' + subroutine.name
-                    print 'calling arguments: ' + str(len(subroutine.calling_vars))
-                    print 'subroutine arguments: ' + str(len(subroutine.arguments))
-                else:
-                    #the number of arguments supplied in the call is greater than the number of non-optional arguments but less than the total of non-optional and optional arguments expected by the subroutine; check for optional arguments
-                    for k in range(len(subroutine.arguments)):
-                        if subroutine.arguments[k].optional.lower() == 't' or subroutine.arguments[k].optional.lower() == 'true':
-                            #for optional arguments, look for arguments being passed in with keywords by id; if the id is not found in the calling variables, then optional_calling_var is an empty list
-                            optional_calling_var = [s for s in subroutine.calling_vars if subroutine.arguments[k].id in s]
-                            if optional_calling_var:
-                                optional_calling_var = optional_calling_var[0].split('=')[1]
-                                new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname, units=subroutine.arguments[k].units, id=subroutine.arguments[k].id, rank=subroutine.arguments[k].rank, type=subroutine.arguments[k].type, description=subroutine.arguments[k].description, kind=subroutine.arguments[k].kind, intent=subroutine.arguments[k].intent, optional=subroutine.arguments[k].optional, calling_var=optional_calling_var)
-                                subroutine.arguments[k] = new_tuple
-                        else:
-                            new_tuple = var_metadata_type(longname=subroutine.arguments[k].longname, units=subroutine.arguments[k].units, id=subroutine.arguments[k].id, rank=subroutine.arguments[k].rank, type=subroutine.arguments[k].type, description=subroutine.arguments[k].description, kind=subroutine.arguments[k].kind, intent=subroutine.arguments[k].intent, optional=subroutine.arguments[k].optional, calling_var=subroutine.calling_vars[k])
-                            subroutine.arguments[k] = new_tuple
-
-
-calling_var_set = set()
-for scheme in schemes:
-    for subroutine in scheme.subroutines:
-        for var in subroutine.arguments:
-            #only add the calling var to the set if it is not empty
-            if(var.calling_var):
-                calling_var_set.add(var.calling_var)
-
-longname_conflicts = []
-longname_success = []
-
-for calling_var in sorted(calling_var_set):
-    #process each calling variable in the set by searching through the schemes / subroutines for where the calling variable is used, saving the calling var, longname, local_name, and subroutine_name for each time a calling variable is used.
-
-    calling_vars = []
-    longnames = []
-    local_names = []
-    subroutine_names = []
+    calling_var_set = set()
     for scheme in schemes:
         for subroutine in scheme.subroutines:
             for var in subroutine.arguments:
-                if var.calling_var == calling_var:
-                    calling_vars.append(calling_var)
-                    longnames.append(var.longname)
-                    local_names.append(var.id)
-                    subroutine_names.append(subroutine.name)
+                #only add the calling var to the set if it is not empty
+                if(var.calling_var):
+                    calling_var_set.add(var.calling_var)
 
-    #check for conflicts; a conflict is when not all longnames used for each calling variable match exactly
-    if longnames.count(longnames[0]) == len(longnames):
-        longname_success.append((calling_vars, longnames, local_names, subroutine_names))
-    else:
-        longname_conflicts.append((calling_vars, longnames, local_names, subroutine_names))
+    find_longname_conflicts(calling_var_set, schemes)
 
-    #print the list of all calling variables and where they are being used
-    print calling_var, subroutine_names
-
-#print the conflicts (or success)
-if len(longname_success) == len(calling_var_set):
-    print "100% success!"
-else:
-    print str(len(longname_conflicts)) + ' conflicts were found out of ' + str(len(calling_var_set)) + ' possible comparisons.'
-    print 'Conflicts:'
-    for conflict in longname_conflicts:
-        for i in range(len(conflict[0])):
-            print conflict[0][i], conflict[1][i], conflict[2][i], conflict[3][i]
-        print #blank line
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New script that employs existing scripts (parse_scheme_table.py, process_tables.py) to automatically check out gmtb-ccpp repositories from defined separators and search for longname conflicts. Includes the possibility to use existing (i.e. once checked out and corrected manually) repositories on a per-separator basis in case modifications are necessary for the script to proceed.