### PR TITLE
Gmtb ccpp gnu support

### DIFF
--- a/src/ccpp_dl.c
+++ b/src/ccpp_dl.c
@@ -79,8 +79,16 @@ ccpp_dl_open(const char *scheme, const char *lib, const char *ver,
 		library = malloc(n);
 		memset(library, 0, n);
 		if (strcmp(ver, "") != 0) {
+#ifdef __APPLE__
+			snprintf(library, n, "%s%s.%s%s", prefix, lib,
+				 ver, suffix);
+#elif defined(__linux__) || defined(__unix__)
 			snprintf(library, n, "%s%s%s.%s", prefix, lib,
 				 suffix, ver);
+#else
+		 	warnx("CCPP library name not configured for this operating system");
+		 	return(EXIT_FAILURE);
+#endif
 		} else {
 			snprintf(library, n, "%s%s%s", prefix, lib, suffix);
 		}


### PR DESCRIPTION
This PR enables support for (reasonably recent) GNU compilers gcc+gfortran on Theia and Cheyenne, as well as for clang+gfortran on MacOSX. The only change required here is the different names of shared libraries and the order of suffix and version string on MacOSX.