### PR TITLE
Match module names and scheme names

### DIFF
--- a/examples/suite_GFS_operational_2017.xml
+++ b/examples/suite_GFS_operational_2017.xml
@@ -15,10 +15,10 @@
       <scheme>GFS_suite_interstitial_rad_reset_run</scheme>
       <scheme>GFS_RRTMG_pre_run</scheme>
       <scheme>GFS_radsw_pre_run</scheme>
-      <scheme>radsw_run</scheme>
+      <scheme>rrtmg_sw_run</scheme>
       <scheme>GFS_radsw_post_run</scheme>
       <scheme>GFS_radlw_pre_run</scheme>
-      <scheme>radlw_run</scheme>
+      <scheme>rrtmg_lw_run</scheme>
       <scheme>GFS_radlw_post_run</scheme>
       <scheme>GFS_RRTMG_post_run</scheme>
       <!-- <scheme>GFS_diagtoscreen_run</scheme> -->
@@ -74,19 +74,19 @@
       <scheme>get_phi_fv3_run</scheme>
       <scheme>GFS_suite_interstitial_3_run</scheme>
       <scheme>GFS_zhao_carr_pre_run</scheme>
-      <scheme>sasasdeep_run</scheme>
+      <scheme>sasas_deep_run</scheme>
       <scheme>GFS_DCNV_generic_post_run</scheme>
       <scheme>gwdc_pre_run</scheme>
       <scheme>gwdc_run</scheme>
       <scheme>gwdc_post_run</scheme>
       <scheme>GFS_SCNV_generic_pre_run</scheme>
-      <scheme>sasasshal_run</scheme>
-      <scheme>sasasshal_post_run</scheme>
+      <scheme>sasas_shal_run</scheme>
+      <scheme>sasas_shal_post_run</scheme>
       <scheme>GFS_SCNV_generic_post_run</scheme>
       <scheme>cnvc90_run</scheme>
       <scheme>GFS_MP_generic_pre_run</scheme>
-      <scheme>gscond_run</scheme>
-      <scheme>precpd_run</scheme>
+      <scheme>zhaocarr_gscond_run</scheme>
+      <scheme>zhaocarr_precpd_run</scheme>
       <scheme>GFS_calpreciptype_run</scheme>
       <scheme>GFS_MP_generic_post_run</scheme>
       <scheme>sfc_diag_run</scheme>

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -94,8 +94,8 @@ caps_dir = 'FV3/gfsphysics/physics'
 # an exception if it encounters a scheme subroutine with optional arguments if no entry is made in
 # the following dictionary. Valid values are 'all', 'none' or a list of arguments: [ 'var1', 'var3' ].
 optional_arguments = {
-    'module_radsw_main' : {
-        'radsw_run' : [
+    'rrtmg_sw' : {
+        'rrtmg_sw_run' : [
             'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
             'components_of_surface_downward_shortwave_fluxes',
             'cloud_liquid_water_path',
@@ -108,8 +108,8 @@ optional_arguments = {
             'mean_effective_radius_for_snow_flake',
             ],
         },
-    'module_radlw_main' : {
-        'radlw_run' : [
+    'rrtmg_lw' : {
+        'rrtmg_lw_run' : [
             'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
             'cloud_liquid_water_path',
             'mean_effective_radius_for_liquid_cloud',

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -387,8 +387,8 @@ def parse_scheme_tables(filename):
                         if subroutine_suffix in subroutine_suffices:
                             scheme_name = subroutine_name[0:subroutine_name.rfind('_')]
                             if not scheme_name == module_name:
-                                logging.error('Scheme name differs from module name: module_name="{0}" vs. scheme_name="{1}"'.format(
-                                                                                                          module_name, scheme_name))
+                                raise Exception('Scheme name differs from module name: module_name="{0}" vs. scheme_name="{1}"'.format(
+                                                                                                             module_name, scheme_name))
                             if not scheme_name in registry[module_name].keys():
                                 registry[module_name][scheme_name] = {}
                             if subroutine_name in registry[module_name][scheme_name].keys():


### PR DESCRIPTION
This PR adds the necessary changes on the gmtb-ccpp side for adjusting module names and scheme names. It also includes a change to the ccpp_prebuild.py script to abort if module names and scheme names do not match.