### PR TITLE
gmtb-ccpp cleanup and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ To add a new scheme one needs to
     
   2. Map all the inputs for the cap from the `cdata` encapsulating
      type (this is of the `ccpp_t` type). The cap will extract the
-     fields from the fields array with the `ccpp_fields_get()`
+     fields from the fields array with the `ccpp_field_get()`
      subroutine. 
 
 An example of a scheme is `schemes/check/test.f90`. It has the cap
@@ -280,7 +280,7 @@ if (ierr /= 0) then
 end if
 
 ! Add surface temperature (variable surf_t).
-call ccpp_fields_add(cdata, 'surface_temperature', surf_t, ierr, 'K')
+call ccpp_field_add(cdata, 'surface_temperature', surf_t, ierr, 'K')
 if (ierr /= 0) then
     call exit(1)
 end if
@@ -299,7 +299,7 @@ real, pointer              :: surf_t(:)
 integer                    :: ierr
 
 call c_f_pointer(ptr, cdata)
-call ccpp_fields_get(cdata, 'surface_temperature', surf_t, ierr)
+call ccpp_field_get(cdata, 'surface_temperature', surf_t, ierr)
 if (ierr /= 0) then
     call exit(1)
 end if

--- a/schemes/check/check_noop.f90
+++ b/schemes/check/check_noop.f90
@@ -22,7 +22,7 @@ module check_noop
     use            :: ccpp_types,                                      &
                       only: ccpp_t
     use            :: ccpp_fields,                                     &
-                      only: ccpp_fields_get
+                      only: ccpp_field_get
     implicit none
 
     private

--- a/schemes/check/nan.f90
+++ b/schemes/check/nan.f90
@@ -22,7 +22,7 @@ module check_nans
     use            :: ccpp_types,                                      &
                       only: ccpp_t
     use            :: ccpp_fields,                                     &
-                      only: ccpp_fields_get
+                      only: ccpp_field_get
     implicit none
 
     private
@@ -41,7 +41,7 @@ module check_nans
 
         call c_f_pointer(ptr, cdata)
 
-        call ccpp_fields_get(cdata, 'northward_wind', v, ierr)
+        call ccpp_field_get(cdata, 'northward_wind', v, ierr)
 
         call test_run(gravity, u, v, surf_t)
 

--- a/schemes/mkcap.py
+++ b/schemes/mkcap.py
@@ -215,7 +215,7 @@ class Var(object):
         '''Print the data retrieval line for the variable.'''
 
         str='''
-        call ccpp_fields_get(cdata, '{s.standard_name}', {s.local_name}, ierr)
+        call ccpp_field_get(cdata, '{s.standard_name}', {s.local_name}, ierr)
         if (ierr /= 0) then
             call ccpp_error('Unable to retrieve {s.standard_name}')
             return
@@ -312,7 +312,7 @@ module {module}_cap
     use            :: ccpp_types,                                      &
                       only: ccpp_t
     use            :: ccpp_fields,                                     &
-                      only: ccpp_fields_get
+                      only: ccpp_field_get
     use            :: ccpp_errors,                                     &
                       only: ccpp_error
     use            :: {module}, &

--- a/schemes/parse_scheme_table.py
+++ b/schemes/parse_scheme_table.py
@@ -3,7 +3,7 @@
 # Usage: ./parse_scheme_table.py filename1 [filename2 filename3 ...]
 # Input: fortran filenames with doxygen-compliant and CCPP-compliant physics schemes; the argument tables should have the following format:
 # !! \section arg_table_schemename_run
-# !! | local var name | longname                                              | description                        | units   | rank | type    |    kind   | intent | optional |
+# !! | local_name     | standard_name                                         | long_name                          | units   | rank | type    |    kind   | intent | optional |
 # !! |----------------|-------------------------------------------------------|------------------------------------|---------|------|---------|-----------|--------|----------|
 # !! | im             | horizontal_loop_extent                                | horizontal loop extent, start at 1 | index   |    0 | integer |           | in     | F        |
 # !! | ix             | horizontal_dimension                                  | horizontal dimension               | index   |    0 | integer |           | in     | F        |

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -66,11 +66,11 @@ scheme_files = [
     'FV3/gfsphysics/physics/precpd.f',
     'FV3/gfsphysics/physics/radlw_main.f',
     'FV3/gfsphysics/physics/radsw_main.f',
+    'FV3/gfsphysics/physics/rayleigh_damp.f',
     'FV3/gfsphysics/physics/rrtmg_lw_post.F90',
     'FV3/gfsphysics/physics/rrtmg_lw_pre.F90',
     'FV3/gfsphysics/physics/rrtmg_sw_post.F90',
     'FV3/gfsphysics/physics/rrtmg_sw_pre.F90',
-    'FV3/gfsphysics/physics/rayleigh_damp.f',
     'FV3/gfsphysics/physics/sfc_diag.f',
     'FV3/gfsphysics/physics/sfc_diff.f',
     'FV3/gfsphysics/physics/sfc_drv.f',
@@ -134,7 +134,7 @@ fields_include_file = 'ccpp_fields.inc'
 # Template code to generate include files                                     #
 ###############################################################################
 
-# Modules to load for auto-generated ccpp_fields_add code (e.g. error handling)
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
 MODULE_USE_TEMPLATE_HOST_CAP = \
 '''
 use ccpp_errors, only: ccpp_error
@@ -142,7 +142,7 @@ use ccpp_errors, only: ccpp_error
 
 CCPP_DATA_STRUCTURE = 'cdata_block(nb,nt)'
 
-# Modules to load for auto-generated ccpp_fields_add code (e.g. error handling)
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
 MODULE_USE_TEMPLATE_SCHEME_CAP = \
 '''
        use machine, only: kind_phys
@@ -313,10 +313,18 @@ def compare_metadata(metadata_define, metadata_request):
             else:
                 logging.error('Unknown identifier {0} in container value of defined variable {1}'.format(subitems[0], var_name))
         target += var.local_name
+        # Copy the length kind from the variable definition to update len=* in the variable requests
+        if var.type == 'character':
+            kind = var.kind
         metadata[var_name] = metadata_request[var_name]
+        # Set target and kind (if applicable)
         for var in metadata[var_name]:
             var.target = target
             logging.debug('Requested variable {0} in {1} matched to target {2} in module {3}'.format(var_name, var.container, target, modules[-1]))
+            # Update len=* for character variables
+            if var.type == 'character' and var.kind == 'len=*':
+                logging.debug('Update kind information for requested variable {0} in {1} from {2} to {3}'.format(var_name, var.container, var.kind, kind))
+                var.kind = kind
 
     # Remove duplicated from list of modules
     modules = sorted(list(set(modules)))
@@ -324,7 +332,7 @@ def compare_metadata(metadata_define, metadata_request):
 
 def create_module_use_statements(modules):
     # MODULE_USE_TEMPLATE_HOST_CAP must include the required modules
-    # for error handling of the ccpp_fields_add statments
+    # for error handling of the ccpp_field_add statments
     logging.info('Generating module use statements ...')
     success = True
     module_use_statements = MODULE_USE_TEMPLATE_HOST_CAP
@@ -335,29 +343,26 @@ def create_module_use_statements(modules):
     logging.info('Generated module use statements for {0} module(s)'.format(cnt))
     return (success, module_use_statements)
 
-def create_ccpp_fields_add_statements(metadata):
+def create_ccpp_field_add_statements(metadata):
     # The metadata container may contain multiple entries
     # for the same variable standard_name, but for different
     # "callers" (i.e. subroutines using it) with potentially
     # different local_name. We only need to add it once to
     # the add_field statement, since the target (i.e. the
     # original variable defined by the model) is the same.
-    logging.info('Generating ccpp_fields_add statements ...')
+    logging.info('Generating ccpp_field_add statements ...')
     success = True
-    ccpp_fields_add_statements = ''
+    ccpp_field_add_statements = ''
     cnt = 0
     for var_name in sorted(metadata.keys()):
         # Add variable with var_name = standard_name once
         var = metadata[var_name][0]
-        standard_name = var.standard_name
-        units = var.units
-        target = var.target
-        ccpp_fields_add_statements += var.print_add(CCPP_DATA_STRUCTURE)
+        ccpp_field_add_statements += var.print_add(CCPP_DATA_STRUCTURE)
         cnt += 1
-    logging.info('Generated ccpp_fields_add statements for {0} variable(s)'.format(cnt))
-    return (success, ccpp_fields_add_statements)
+    logging.info('Generated ccpp_field_add statements for {0} variable(s)'.format(cnt))
+    return (success, ccpp_field_add_statements)
 
-def generate_include_files(module_use_statements, ccpp_fields_add_statements):
+def generate_include_files(module_use_statements, ccpp_field_add_statements):
     logging.info('Generating include files for host model cap {0} ...'.format(', '.join(target_files)))
     success = True
     target_dirs = []
@@ -370,11 +375,11 @@ def generate_include_files(module_use_statements, ccpp_fields_add_statements):
         logging.info('Generated module-use include file {0}'.format(includefile))
         with open(includefile, "w") as f:
             f.write(module_use_statements)
-        # ccpp_fields_add statements
+        # ccpp_field_add statements
         includefile = os.path.join(target_dir, fields_include_file)
         logging.info('Generated fields-add include file {0}'.format(includefile))
         with open(includefile, "w") as f:
-            f.write(ccpp_fields_add_statements)
+            f.write(ccpp_field_add_statements)
     return success
 
 def generate_scheme_caps(metadata, arguments):
@@ -476,12 +481,12 @@ def main():
         raise Exception('Call to create_module_use_statements failed.')
 
     # Crate ccpp_fiels_add statements to inject into the host model cap
-    (success, ccpp_fields_add_statements) = create_ccpp_fields_add_statements(metadata)
+    (success, ccpp_field_add_statements) = create_ccpp_field_add_statements(metadata)
     if not success:
-        raise Exception('Call to create_ccpp_fields_add_statements failed.')
+        raise Exception('Call to create_ccpp_field_add_statements failed.')
 
-    # Generate include files for module_use_statements and ccpp_fields_add_statements
-    success = generate_include_files(module_use_statements, ccpp_fields_add_statements)
+    # Generate include files for module_use_statements and ccpp_field_add_statements
+    success = generate_include_files(module_use_statements, ccpp_field_add_statements)
     if not success:
         raise Exception('Call to generate_include_files failed.')
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -33,7 +33,7 @@ def execute(cmd, abort = True):
     return (status, stdout.rstrip('\n'), stderr.rstrip('\n'))
 
 
-#subroutine for writing "pretty" XML; copied from http://effbot.org/zone/element-lib.htm#prettyprint
+# Subroutine for writing "pretty" XML; copied from http://effbot.org/zone/element-lib.htm#prettyprint
 def indent(elem, level=0):
   i = "\n" + level*"  "
   if len(elem):
@@ -58,22 +58,3 @@ def encode_container(*args):
     elif len(args)==1:
         container = 'MODULE_{0}'.format(*args)
     return container
-
-
-#def decode_container(container)
-#    args = []
-#    for arg in container.split(' '):
-#        
-#def dict_sweep(dictionary, value):
-#    for key in dictionary.keys():
-#        if dictionary.get(key) is dict:
-#            print "Decending into subtree {0}".format(key)
-#            dictionary[key] = dict_sweep(dictionary[key])
-#        elif dictionary.get(key) is list:
-#            if value in dictionary[key]:
-#                print "Deleting value {0} from list {1} for key {2}".format(value, dictionary[key], key)
-#                dictionary[key] = dictionary[key].remove(value)
-#        elif dictionary.get(key) == value:
-#            print "Deleting key-value pair {0} {1} from dictionary".format(key, value)
-#            del dictionary[key]
-#    return dictionary

--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -10,11 +10,13 @@ from mkcap import Var
 
 # The argument tables for schemes and variable definitions should have the following format:
 # !! \section arg_table_SubroutineName (e.g. SubroutineName = SchemeName_run) OR \section arg_table_DerivedTypeName OR \section arg_table_ModuleName
-# !! | local var name | longname                                              | description                        | units   | rank | type    |    kind   | intent | optional |
-# !! |----------------|-------------------------------------------------------|------------------------------------|---------|------|---------|-----------|--------|----------|
-# !! | im             | horizontal_loop_extent                                | horizontal loop extent, start at 1 | index   |    0 | integer |           | in     | F        |
-# !! | ix             | horizontal_dimension                                  | horizontal dimension               | index   |    0 | integer |           | in     | F        |
-# !! | ...            | ...                                                   |                                    |         |      |         |           |        |          |
+# !! | local_name     | standard_name                                         | long_name                                | units   | rank | type      |    kind   | intent | optional |
+# !! |----------------|-------------------------------------------------------|------------------------------------------|---------|------|-----------|-----------|--------|----------|
+# !! | im             | horizontal_loop_extent                                | horizontal loop extent, start at 1       | index   |    0 | integer   |           | in     | F        |
+# !! | ix             | horizontal_dimension                                  | horizontal dimension                     | index   |    0 | integer   |           | in     | F        |
+# !! | ...            | ...                                                   |                                          |         |      |           |           |        |          |
+# !! | errmsg         | error_message                                         | error message for error handling in CCPP | none    |    0 | character |           | out    | F        |
+# !! | ierr           | error_flag                                            | error flag for error handling in CCPP    | none    |    0 | integer   |           | out    | F        |
 # !!
 # Notes on the input format:
 # - if the argument table starts a new doxygen section, it should start with !> \section instead of !! \section
@@ -28,22 +30,46 @@ from mkcap import Var
 # - table headers are the first row, the second row must have the |---|-----| format
 # - after the last row of the table, there must be a blank doxygen line (only '!!') to denote the end of the table
 # - for variable type definitions and module variables, the intent and optional columns must be set to 'none' and 'F'
+# - each argument table (and its subroutine) must accept the following two arguments for error handling:
+#      - character(len=512), intent(out) :: errmsg
+#          - errmsg must be initialized as '' and contains the error message in case an error occurs
+#      - integer, intent(out) :: ierr
+#          - ierr must be initialized as 0 and set to >1 in case of errors
 # Output: This routine converts the argument tables for all subroutines / typedefs / module variables into an XML file
 # suitable to be used with mkcap.py (which generates the fortran code for the scheme cap)
 # - the script generates a separate file for each module within the given files
 
 
 VALID_ITEMS = {
-    # DH* TODO RENAME COLUMN HEADERS IN METADATA TABLES
-    #'header' : ['local_name', 'standard_name', 'long_name', 'units', 'rank', 'type', 'kind', 'intent', 'optional'],
-    'header' : ['local var name', 'longname', 'description', 'units', 'rank', 'type', 'kind', 'intent', 'optional'],
-    # *DH
-    #'type' : ['character', 'integer', 'real'],
-    #'kind' : ['default', 'kind_phys'],
+    'header' : ['local_name', 'standard_name', 'long_name', 'units', 'rank', 'type', 'kind', 'intent', 'optional'],
+    #'type' : ['character', 'integer', 'real', ...],
+    #'kind' : ['default', 'kind_phys', ...],
     'intent' : ['none', 'in', 'out', 'inout'],
     'optional' : ['T', 'F'],
     }
 
+CCPP_MANDATORY_VARIABLES = {
+    'error_message' : Var(local_name    = 'errmsg',
+                          standard_name = 'error_message',
+                          long_name     = 'error message for error handling in CCPP',
+                          units         = 'none',
+                          type          = 'character',
+                          rank          = '',
+                          kind          = 'len=*',
+                          intent        = 'out',
+                          optional      = 'F'
+                          ),
+    'error_flag' : Var(local_name    = 'ierr',
+                       standard_name = 'error_flag',
+                       long_name     = 'error flag for error handling in CCPP',
+                       units         = 'flag',
+                       type          = 'integer',
+                       rank          = '',
+                       kind          = '',
+                       intent        = 'out',
+                       optional      = 'F'
+                       ),
+    }
 
 def merge_metadata_dicts(x, y):
     """Give up the order of variables - fine."""
@@ -198,15 +224,9 @@ def parse_variable_tables(filename):
                             raise Exception('Invalid column header {0} in argument table {1}'.format(item, table_name))
                     # Locate mandatory column 'standard_name'
                     try:
-                        # DH* TODO RENAME COLUMN HEADERS IN METADATA TABLES
-                        #standard_name_index = table_header.index('standard_name')
-                        standard_name_index = table_header.index('longname')
-                        # *DH
+                        standard_name_index = table_header.index('standard_name')
                     except ValueError:
-                        # DH* TODO RENAME COLUMN HEADERS IN METADATA TABLES
-                        #raise Exception('Mandatory column standard_name not found in argument table of subroutine {0}'.format(sub_name))
-                        raise Exception('Mandatory column longname not found in argument table {0}'.format(table_name))
-                        # *DH
+                        raise Exception('Mandatory column standard_name not found in argument table {0}'.format(table_name))
                     line_counter += 1
                     continue
                 elif current_line_number == header_line_number + 1:
@@ -235,6 +255,13 @@ def parse_variable_tables(filename):
                             else:
                                 container = encode_container(module_name, table_name)
                             var.container = container
+                            # Check for incompatible definitions with CCPP mandatory variables
+                            if var_name in CCPP_MANDATORY_VARIABLES.keys() and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
+                                raise Exception('Entry for variable {0}'.format(var_name) + \
+                                                ' in argument table {0}'.format(table_name) +\
+                                                ' is incompatible with mandatory variable:\n' +\
+                                                '    existing: {0}\n'.format(CCPP_MANDATORY_VARIABLES[var_name].print_debug()) +\
+                                                '     vs. new: {0}'.format(var.print_debug()))
                             # Add variable to metadata dictionary
                             if not var_name in metadata.keys():
                                 metadata[var_name] = [var]
@@ -464,15 +491,9 @@ def parse_scheme_tables(filename):
                             raise Exception('Invalid column header {0} in argument table {1}'.format(item, table_name))
                     # Locate mandatory column 'standard_name'
                     try:
-                        # DH* TODO RENAME COLUMN HEADERS IN METADATA TABLES
-                        #standard_name_index = table_header.index('standard_name')
-                        standard_name_index = table_header.index('longname')
-                        # *DH
+                        standard_name_index = table_header.index('standard_name')
                     except ValueError:
-                        # DH* TODO RENAME COLUMN HEADERS IN METADATA TABLES
-                        #raise Exception('Mandatory column standard_name not found in argument table of subroutine {0}'.format(sub_name))
-                        raise Exception('Mandatory column longname not found in argument table {0}'.format(table_name))
-                        # *DH
+                        raise Exception('Mandatory column standard_name not found in argument table {0}'.format(table_name))
                     # Get all of the variable information in table
                     end_of_table = False
                     line_number = header_line_number + 2
@@ -489,12 +510,20 @@ def parse_scheme_tables(filename):
                             if not len(var_items) == len(table_header):
                                 raise Exception('Error parsing variable entry "{0}" in argument table {1}'.format(var_items, table_name))
                             var_name = var_items[standard_name_index]
-                            # standard_name cannot be left blank in scheme_tables
+                            # Column standard_name cannot be left blank in scheme_tables
                             if not var_name:
                                 raise Exception('Encountered line "{0}" without standard name in argument table {1}'.format(line, table_name))
                             # Add standard_name to argument list for this subroutine
                             arguments[module_name][scheme_name][subroutine_name].append(var_name)
                             var = Var.from_table(table_header,var_items)
+                            # Check for incompatible definitions with CCPP mandatory variables
+                            if var_name in CCPP_MANDATORY_VARIABLES.keys() and not CCPP_MANDATORY_VARIABLES[var_name].compatible(var):
+                                raise Exception('Entry for variable {0}'.format(var_name) + \
+                                                ' in argument table of subroutine {0}'.format(subroutine_name) +\
+                                                ' is incompatible with mandatory variable:\n' +\
+                                                '    existing: {0}\n'.format(CCPP_MANDATORY_VARIABLES[var_name].print_debug()) +\
+                                                '     vs. new: {0}'.format(var.print_debug()))
+                            # Record the location of this variable: module, scheme, table
                             container = encode_container(module_name, scheme_name, table_name)
                             var.container = container
                             # Add variable to metadata dictionary
@@ -511,6 +540,12 @@ def parse_scheme_tables(filename):
                                 metadata[var_name].append(var)
 
                         line_number += 1
+
+                    # After parsing entire metadata table for the subroutine, check that all mandatory CCPP variables are present
+                    for var_name in CCPP_MANDATORY_VARIABLES.keys():
+                        if not var_name in arguments[module_name][scheme_name][subroutine_name]:
+                            raise Exception('Mandatory CCPP variable {0} not declared in metadata table of subroutine {1}'.format(
+                                                                                                       var_name, subroutine_name))
 
         # For CCPP-compliant files (i.e. files with metadata tables, perform additional checks)
         if len(metadata.keys()) > 0:

--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -12,6 +12,8 @@ import xml.etree.ElementTree as ET
 
 STANDARD_VARIABLE_TYPES = [ 'character', 'integer', 'logical', 'real' ]
 
+CCPP_ERROR_FLAG_VARIABLE = 'error_flag'
+
 #################### Main program routine
 def main():
     args = parse_args()
@@ -157,6 +159,8 @@ class Var(object):
 
     @type.setter
     def type(self, value):
+        if value == 'character' and self._rank:
+            raise Exception('Arrays of Fortran strings not implemented in CCPP')
         self._type = value
 
     @property
@@ -168,6 +172,8 @@ class Var(object):
     def rank(self, value):
         if not isinstance(value, int):
             raise TypeError('Invalid type for variable property rank, must be integer')
+        elif self.type == 'character' and value > 0:
+            raise Exception('Arrays of Fortran strings not implemented in CCPP')
         if (value == 0):
             self._rank = ''
         else:
@@ -214,6 +220,14 @@ class Var(object):
         self._container = value
 
     def compatible(self, other):
+        # We accept character(len=*) as compatible with character(len=INTEGER_VALUE)
+        if self.type == 'character':
+            if (self.kind == 'len=*' and other.kind.startswith('len=')) or \
+                   (self.kind.startswith('len=') and other.kind == 'len=*'):
+                return self.standard_name == other.standard_name \
+                    and self.units == other.units \
+                    and self.type == other.type \
+                    and self.rank == other.rank
         return self.standard_name == other.standard_name \
             and self.units == other.units \
             and self.type == other.type \
@@ -224,9 +238,9 @@ class Var(object):
         '''Print the definition line for the variable.'''
         if self.type in STANDARD_VARIABLE_TYPES:
             if self.kind:
-                str = "{s.type}({s._kind}), pointer     :: {s.local_name}{s.rank}"
+                str = "{s.type}({s._kind}), pointer :: {s.local_name}{s.rank}"
             else:
-                str = "{s.type}, pointer     :: {s.local_name}{s.rank}"
+                str = "{s.type}, pointer :: {s.local_name}{s.rank}"
         else:
             if self.kind:
                 error_message = "Generating variable definition statements for derived types with" + \
@@ -238,30 +252,32 @@ class Var(object):
 
     def print_get(self):
         '''Print the data retrieval line for the variable. Depends on the type and of variable'''
-        # Standard-type variables, scalar and array
         if self.type in STANDARD_VARIABLE_TYPES:
             str='''
-            call ccpp_fields_get(cdata, '{s.standard_name}', {s.local_name}, ierr)
-            if (ierr /= 0) then
-                call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
-            end if'''
+        call ccpp_field_get(cdata, '{s.standard_name}', {s.local_name}, ierr)
+        if (ierr /= 0) then
+            call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
+            return
+        end if'''
         # Derived-type variables, scalar
         elif self.rank == '':
             str='''
-            call ccpp_fields_get(cdata, '{s.standard_name}', cptr, ierr)
-            if (ierr /= 0) then
-                call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
-            end if
-            call c_f_pointer(cptr, {s.local_name})'''
+        call ccpp_field_get(cdata, '{s.standard_name}', cptr, ierr)
+        if (ierr /= 0) then
+            call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
+            return
+        end if
+        call c_f_pointer(cptr, {s.local_name})'''
         # Derived-type variables, array
         else:
             str='''
-            call ccpp_fields_get(cdata, '{s.standard_name}', cptr, ierr, dims=cdims)
-            if (ierr /= 0) then
-                call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
-            end if
-            call c_f_pointer(cptr, {s.local_name}, cdims)
-            deallocate(cdims)'''
+        call ccpp_field_get(cdata, '{s.standard_name}', cptr, ierr, dims=cdims)
+        if (ierr /= 0) then
+            call ccpp_error('Unable to retrieve {s.standard_name} from CCPP data structure')
+            return
+        end if
+        call c_f_pointer(cptr, {s.local_name}, cdims)
+        deallocate(cdims)'''
         return str.format(s=self)
 
     def print_add(self, ccpp_data_structure):
@@ -270,7 +286,7 @@ class Var(object):
         # Standard-type variables, scalar and array
         if self.type in STANDARD_VARIABLE_TYPES:
             str='''
-            call ccpp_fields_add({ccpp_data_structure}, '{s.standard_name}', {s.target}, ierr, '{s.units}')
+            call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', {s.target}, ierr, '{s.units}')
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
                 return
@@ -278,7 +294,7 @@ class Var(object):
         # Derived-type variables, scalar
         elif self.rank == '':
             str='''
-            call ccpp_fields_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), ierr)
+            call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), ierr)
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
                 return
@@ -286,7 +302,7 @@ class Var(object):
         # Derived-type variables, array
         else:
             str='''
-            call ccpp_fields_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), rank=size({s.target}), dims=shape({s.target}), ierr=ierr)
+            call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), rank=size(shape({s.target})), dims=shape({s.target}), ierr=ierr)
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
                 return
@@ -311,20 +327,15 @@ class Var(object):
     @classmethod
     def from_table(cls, columns, data):
         var = cls()
-        # DH* TODO RENAME COLUMNS IN TABLES
-        var.standard_name = data[columns.index('longname')]
-        #var.standard_name = data[columns.index('standard_name')]
-        var.long_name     = data[columns.index('description')]
-        #var.long_name     = data[columns.index('long_name')]
+        var.standard_name = data[columns.index('standard_name')]
+        var.long_name     = data[columns.index('long_name')]
         var.units         = data[columns.index('units')]
-        #var.local_name    = data[columns.index('local_name')]
-        var.local_name    = data[columns.index('local var name')]
+        var.local_name    = data[columns.index('local_name')]
         var.rank          = int(data[columns.index('rank')])
         var.type          = data[columns.index('type')]
         var.kind          = data[columns.index('kind')]
         var.intent        = data[columns.index('intent')]
         var.optional      = data[columns.index('optional')]
-        # *DH
         return var
 
     def to_xml(self, element):
@@ -373,13 +384,13 @@ class Cap(object):
 module {module}_cap
 
     use, intrinsic :: iso_c_binding,                                   &
-                      only: c_f_pointer, c_ptr
+                      only: c_f_pointer, c_ptr, c_int32_t
     use            :: ccpp_types,                                      &
                       only: ccpp_t
     use            :: ccpp_fields,                                     &
-                      only: ccpp_fields_get
+                      only: ccpp_field_get
     use            :: ccpp_errors,                                     &
-                      only: ccpp_error
+                      only: ccpp_error, ccpp_debug
     use            :: {module}, &
                       only: {subroutines}
     ! Other modules required, e.g. type definitions
@@ -395,23 +406,26 @@ module {module}_cap
 '''
 
     sub='''
-    subroutine {subroutine}_cap(ptr) bind(c)
+    function {subroutine}_cap(ptr) bind(c) result(ierr)
 
+        integer(c_int32_t)         :: ierr
         type(c_ptr), intent(inout) :: ptr
 
-        type(ccpp_t), pointer      :: cdata
-        type(c_ptr)                :: cptr
-        integer, allocatable       :: cdims(:)
-        integer                    :: ierr
+        type(ccpp_t), pointer           :: cdata
+        type(c_ptr)                     :: cptr
+        integer, allocatable            :: cdims(:)
 {var_defs}
+
+        ierr = 0
 
         call c_f_pointer(ptr, cdata)
 
 {var_gets}
 
         call {subroutine}({args})
+        {ierr_assign}
 
-    end subroutine {subroutine}_cap
+    end function {subroutine}_cap
 '''
 
     def __init__(self, **kwargs):
@@ -439,9 +453,9 @@ module {module}_cap
             f.write(Cap.sub.format(subroutine=k,
                                    var_defs=var_defs,
                                    var_gets=var_gets,
-                                   args=args))
-
-        f.write("end module {module}_cap\n".format(moduleZ= data['module']))
+                                   args=args,
+                                   ierr_assign=''))
+        f.write("end module {module}_cap\n".format(module=data['module']))
 
         if (f is not sys.stdout):
             f.close()
@@ -474,11 +488,18 @@ module {module}_cap
                     args += ' &\n                  '
                     length = 0
             args = args.rstrip(',')
+            # If CCPP_ERROR_FLAG_VARIABLE is present, assign to ierr
+            ierr_assign = ''
+            for x in data[sub]:
+                if x.standard_name == CCPP_ERROR_FLAG_VARIABLE:
+                    ierr_assign = 'ierr={x.local_name}'.format(x=x)
+                    break
             # Write to scheme cap
             f.write(Cap.sub.format(subroutine=sub,
                                    var_defs=var_defs,
                                    var_gets=var_gets,
-                                   args=args))
+                                   args=args,
+                                   ierr_assign=ierr_assign))
         f.write("end module {module}_cap\n".format(module = module))
 
         if (f is not sys.stdout):

--- a/src/ccpp_dl.c
+++ b/src/ccpp_dl.c
@@ -164,19 +164,16 @@ ccpp_dl_close(void **lhdl)
  * @param[in] f_ptr     The scheme function pointer to call.
  * @param[in] data      The opaque ccpp_t data type to pass.
  * @retval     0        If it was sucessful
- * @retval     1        If there was an error
+ * @retval    !=0       If there was an error
  **/
 int
 ccpp_dl_call(void **f_ptr, void **data)
 {
-	void (*fun)(void **) = NULL;
+	int (*fun)(void **) = NULL;
 
-	*(void **)(&fun) = *f_ptr;
+	*(int **)(&fun) = *f_ptr;
 
-	/* Call the schemes cap subroutine */
-	fun(data);
-
-	return(EXIT_SUCCESS);
+	return(fun(data));
 }
 
 /**

--- a/src/ccpp_fields.F90
+++ b/src/ccpp_fields.F90
@@ -24,7 +24,7 @@
 !! @code{.f90}
 !!
 !! ! Add a field, for example the eastward_wind.
-!! call ccpp_fields_add(ipd_data, 'eastward_wind', &
+!! call ccpp_field_add(ipd_data, 'eastward_wind', &
 !!                      u, ierr, 'm s-1')
 !! if (ierr /= 0) then
 !!   call exit(ierr)
@@ -36,7 +36,7 @@
 !! @code{.f90}
 !!
 !! ! Extract a field, for example the eastward_wind.
-!! call ccpp_fields_get(ipd_data, 'eastward_wind', u, ierr)
+!! call ccpp_field_get(ipd_data, 'eastward_wind', u, ierr)
 !! if (ierr /= 0) then
 !!   call exit(ierr)
 !! end if
@@ -55,7 +55,7 @@ module ccpp_fields
     use            :: ccpp_strings,                                     &
                       only: ccpp_cstr
     use            :: ccpp_errors,                                      &
-                      only: ccpp_debug, ccpp_warn
+                      only: ccpp_debug, ccpp_warn, ccpp_error
 
     implicit none
 
@@ -63,117 +63,125 @@ module ccpp_fields
     public :: ccpp_fields_init,                                        &
               ccpp_fields_finalize,                                    &
               ccpp_fields_find,                                        &
-              ccpp_fields_add,                                         &
-              ccpp_fields_get
+              ccpp_field_add,                                          &
+              ccpp_field_get
+
+    ! DH* TODO can use new Fortran syntax?
+    !           type(*), dimension(..), intent(in) :: a
+    !           for arrays of any type, any rank? *DH
 
     !>
     !! Module precedence for adding a field.
     !
-    interface ccpp_fields_add
-        module procedure           &
-            ccpp_fields_add_i32_0, &
-            ccpp_fields_add_i32_1, &
-            ccpp_fields_add_i32_2, &
-            ccpp_fields_add_i32_3, &
-            ccpp_fields_add_i32_4, &
-            ccpp_fields_add_i32_5, &
-            ccpp_fields_add_i32_6, &
-            ccpp_fields_add_i32_7, &
+    interface ccpp_field_add
+        module procedure          &
+            ccpp_field_add_i32_0, &
+            ccpp_field_add_i32_1, &
+            ccpp_field_add_i32_2, &
+            ccpp_field_add_i32_3, &
+            ccpp_field_add_i32_4, &
+            ccpp_field_add_i32_5, &
+            ccpp_field_add_i32_6, &
+            ccpp_field_add_i32_7, &
 
-            ccpp_fields_add_i64_0, &
-            ccpp_fields_add_i64_1, &
-            ccpp_fields_add_i64_2, &
-            ccpp_fields_add_i64_3, &
-            ccpp_fields_add_i64_4, &
-            ccpp_fields_add_i64_5, &
-            ccpp_fields_add_i64_6, &
-            ccpp_fields_add_i64_7, &
+            ccpp_field_add_i64_0, &
+            ccpp_field_add_i64_1, &
+            ccpp_field_add_i64_2, &
+            ccpp_field_add_i64_3, &
+            ccpp_field_add_i64_4, &
+            ccpp_field_add_i64_5, &
+            ccpp_field_add_i64_6, &
+            ccpp_field_add_i64_7, &
 
-            ccpp_fields_add_r32_0, &
-            ccpp_fields_add_r32_1, &
-            ccpp_fields_add_r32_2, &
-            ccpp_fields_add_r32_3, &
-            ccpp_fields_add_r32_4, &
-            ccpp_fields_add_r32_5, &
-            ccpp_fields_add_r32_6, &
-            ccpp_fields_add_r32_7, &
+            ccpp_field_add_r32_0, &
+            ccpp_field_add_r32_1, &
+            ccpp_field_add_r32_2, &
+            ccpp_field_add_r32_3, &
+            ccpp_field_add_r32_4, &
+            ccpp_field_add_r32_5, &
+            ccpp_field_add_r32_6, &
+            ccpp_field_add_r32_7, &
 
-            ccpp_fields_add_r64_0, &
-            ccpp_fields_add_r64_1, &
-            ccpp_fields_add_r64_2, &
-            ccpp_fields_add_r64_3, &
-            ccpp_fields_add_r64_4, &
-            ccpp_fields_add_r64_5, &
-            ccpp_fields_add_r64_6, &
-            ccpp_fields_add_r64_7, &
+            ccpp_field_add_r64_0, &
+            ccpp_field_add_r64_1, &
+            ccpp_field_add_r64_2, &
+            ccpp_field_add_r64_3, &
+            ccpp_field_add_r64_4, &
+            ccpp_field_add_r64_5, &
+            ccpp_field_add_r64_6, &
+            ccpp_field_add_r64_7, &
 
-            ccpp_fields_add_l_0, &
-            ccpp_fields_add_l_1, &
-            ccpp_fields_add_l_2, &
-            ccpp_fields_add_l_3, &
-            ccpp_fields_add_l_4, &
-            ccpp_fields_add_l_5, &
-            ccpp_fields_add_l_6, &
-            ccpp_fields_add_l_7, &
+            ccpp_field_add_l_0,   &
+            ccpp_field_add_l_1,   &
+            ccpp_field_add_l_2,   &
+            ccpp_field_add_l_3,   &
+            ccpp_field_add_l_4,   &
+            ccpp_field_add_l_5,   &
+            ccpp_field_add_l_6,   &
+            ccpp_field_add_l_7,   &
 
-            ccpp_fields_add_ptr
-    end interface ccpp_fields_add
+            ccpp_field_add_c_0,   &
+
+            ccpp_field_add_ptr
+    end interface ccpp_field_add
 
     !>
     !! Module precedence for getting a field.
     !
-    interface ccpp_fields_get
-        module procedure           &
-            ccpp_fields_get_i32_0, &
-            ccpp_fields_get_i32_1, &
-            ccpp_fields_get_i32_2, &
-            ccpp_fields_get_i32_3, &
-            ccpp_fields_get_i32_4, &
-            ccpp_fields_get_i32_5, &
-            ccpp_fields_get_i32_6, &
-            ccpp_fields_get_i32_7, &
+    interface ccpp_field_get
+        module procedure          &
+            ccpp_field_get_i32_0, &
+            ccpp_field_get_i32_1, &
+            ccpp_field_get_i32_2, &
+            ccpp_field_get_i32_3, &
+            ccpp_field_get_i32_4, &
+            ccpp_field_get_i32_5, &
+            ccpp_field_get_i32_6, &
+            ccpp_field_get_i32_7, &
 
-            ccpp_fields_get_i64_0, &
-            ccpp_fields_get_i64_1, &
-            ccpp_fields_get_i64_2, &
-            ccpp_fields_get_i64_3, &
-            ccpp_fields_get_i64_4, &
-            ccpp_fields_get_i64_5, &
-            ccpp_fields_get_i64_6, &
-            ccpp_fields_get_i64_7, &
+            ccpp_field_get_i64_0, &
+            ccpp_field_get_i64_1, &
+            ccpp_field_get_i64_2, &
+            ccpp_field_get_i64_3, &
+            ccpp_field_get_i64_4, &
+            ccpp_field_get_i64_5, &
+            ccpp_field_get_i64_6, &
+            ccpp_field_get_i64_7, &
 
-            ccpp_fields_get_r32_0, &
-            ccpp_fields_get_r32_1, &
-            ccpp_fields_get_r32_2, &
-            ccpp_fields_get_r32_3, &
-            ccpp_fields_get_r32_4, &
-            ccpp_fields_get_r32_5, &
-            ccpp_fields_get_r32_6, &
-            ccpp_fields_get_r32_7, &
+            ccpp_field_get_r32_0, &
+            ccpp_field_get_r32_1, &
+            ccpp_field_get_r32_2, &
+            ccpp_field_get_r32_3, &
+            ccpp_field_get_r32_4, &
+            ccpp_field_get_r32_5, &
+            ccpp_field_get_r32_6, &
+            ccpp_field_get_r32_7, &
 
-            ccpp_fields_get_r64_0, &
-            ccpp_fields_get_r64_1, &
-            ccpp_fields_get_r64_2, &
-            ccpp_fields_get_r64_3, &
-            ccpp_fields_get_r64_4, &
-            ccpp_fields_get_r64_5, &
-            ccpp_fields_get_r64_6, &
-            ccpp_fields_get_r64_7, &
+            ccpp_field_get_r64_0, &
+            ccpp_field_get_r64_1, &
+            ccpp_field_get_r64_2, &
+            ccpp_field_get_r64_3, &
+            ccpp_field_get_r64_4, &
+            ccpp_field_get_r64_5, &
+            ccpp_field_get_r64_6, &
+            ccpp_field_get_r64_7, &
 
-            ccpp_fields_get_l_0, &
-            ccpp_fields_get_l_1, &
-            ccpp_fields_get_l_2, &
-            ccpp_fields_get_l_3, &
-            ccpp_fields_get_l_4, &
-            ccpp_fields_get_l_5, &
-            ccpp_fields_get_l_6, &
-            ccpp_fields_get_l_7, &
+            ccpp_field_get_l_0,   &
+            ccpp_field_get_l_1,   &
+            ccpp_field_get_l_2,   &
+            ccpp_field_get_l_3,   &
+            ccpp_field_get_l_4,   &
+            ccpp_field_get_l_5,   &
+            ccpp_field_get_l_6,   &
+            ccpp_field_get_l_7,   &
 
-            ccpp_fields_get_ptr
-    end interface ccpp_fields_get
+            ccpp_field_get_c_0,   &
+
+            ccpp_field_get_ptr
+    end interface ccpp_field_get
 
     !>
-    !! Interface to all the C field index funtions.
+    !! Interface to all the C field index functions.
     !
     interface
        integer(c_int32_t)                                              &
@@ -287,7 +295,7 @@ module ccpp_fields
     !! @param[in   ]  dims          Optional dimensions of the data.
     !! @param[  out]  ierr          Integer error flag.
     !
-    subroutine ccpp_fields_add_ptr(cdata, standard_name, units, ptr, &
+    subroutine ccpp_field_add_ptr(cdata, standard_name, units, ptr, &
                                    rank, dims, ierr)
         type(ccpp_t),                    intent(inout) :: cdata
         character(len=*),                intent(in)    :: standard_name
@@ -303,7 +311,7 @@ module ccpp_fields
         integer                                        :: new_fields_max
         type(ccpp_field_t), allocatable, dimension(:)  :: tmp
 
-        call ccpp_debug('Called ccpp_fields_add_ptr for field ' // trim(standard_name))
+        call ccpp_debug('Called ccpp_field_add_ptr for field ' // trim(standard_name))
 
         ierr_local = 0
 
@@ -353,7 +361,7 @@ module ccpp_fields
 
         if (present(ierr)) ierr=ierr_local
 
-    end subroutine ccpp_fields_add_ptr
+    end subroutine ccpp_field_add_ptr
 
     !>
     !! CCPP fields retrieval subroutine.
@@ -366,7 +374,7 @@ module ccpp_fields
     !! @param[  out]  rank          Optional rank of the data.
     !! @param[  out]  dims          Optional dimensions of the data.
     !
-    subroutine ccpp_fields_get_ptr(cdata, standard_name, ptr, ierr, &
+    subroutine ccpp_field_get_ptr(cdata, standard_name, ptr, ierr, &
                                    units, rank, dims)
         type(ccpp_t),                    intent(inout) :: cdata
         character(len=*),                intent(in)    :: standard_name
@@ -379,7 +387,7 @@ module ccpp_fields
         integer                                        :: idx
         integer                                        :: ierr_local
 
-        call ccpp_debug('Called ccpp_fields_get_ptr for field ' // trim(standard_name))
+        call ccpp_debug('Called ccpp_field_get_ptr for field ' // trim(standard_name))
 
         ierr_local = 0
 
@@ -416,7 +424,7 @@ module ccpp_fields
 
         if (present(ierr)) ierr=ierr_local
 
-    end subroutine ccpp_fields_get_ptr
+    end subroutine ccpp_field_get_ptr
 
 
     !>
@@ -449,7 +457,7 @@ module ccpp_fields
     !! Single precision (32-bit) integer field addition subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_add_i32_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr
@@ -457,12 +465,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_0
+    end subroutine ccpp_field_add_i32_0
 
-    subroutine ccpp_fields_add_i32_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:)
@@ -470,12 +478,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_1
+    end subroutine ccpp_field_add_i32_1
 
-    subroutine ccpp_fields_add_i32_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:)
@@ -483,12 +491,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_2
+    end subroutine ccpp_field_add_i32_2
 
-    subroutine ccpp_fields_add_i32_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:,:)
@@ -496,12 +504,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_3
+    end subroutine ccpp_field_add_i32_3
 
-    subroutine ccpp_fields_add_i32_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:,:,:)
@@ -509,12 +517,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_4
+    end subroutine ccpp_field_add_i32_4
 
-    subroutine ccpp_fields_add_i32_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:,:,:,:)
@@ -522,12 +530,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_5
+    end subroutine ccpp_field_add_i32_5
 
-    subroutine ccpp_fields_add_i32_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:,:,:,:,:)
@@ -535,12 +543,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_6
+    end subroutine ccpp_field_add_i32_6
 
-    subroutine ccpp_fields_add_i32_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i32_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT32), target, intent(in)    :: ptr(:,:,:,:,:,:,:)
@@ -548,17 +556,17 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i32_7
+    end subroutine ccpp_field_add_i32_7
 
     !------------------------------------------------------------------!
     !>
     !! Double precision (64-bit) integer field addition subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_add_i64_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr
@@ -566,12 +574,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_0
+    end subroutine ccpp_field_add_i64_0
 
-    subroutine ccpp_fields_add_i64_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:)
@@ -579,12 +587,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_1
+    end subroutine ccpp_field_add_i64_1
 
-    subroutine ccpp_fields_add_i64_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:)
@@ -592,12 +600,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_2
+    end subroutine ccpp_field_add_i64_2
 
-    subroutine ccpp_fields_add_i64_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:,:)
@@ -605,12 +613,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_3
+    end subroutine ccpp_field_add_i64_3
 
-    subroutine ccpp_fields_add_i64_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:,:,:)
@@ -618,12 +626,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_4
+    end subroutine ccpp_field_add_i64_4
 
-    subroutine ccpp_fields_add_i64_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:,:,:,:)
@@ -631,12 +639,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_5
+    end subroutine ccpp_field_add_i64_5
 
-    subroutine ccpp_fields_add_i64_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:,:,:,:,:)
@@ -644,12 +652,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_6
+    end subroutine ccpp_field_add_i64_6
 
-    subroutine ccpp_fields_add_i64_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_i64_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         integer(kind=INT64), target, intent(in)    :: ptr(:,:,:,:,:,:,:)
@@ -657,17 +665,17 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_i64_7
+    end subroutine ccpp_field_add_i64_7
 
     !------------------------------------------------------------------!
     !>
     !! Single precision (32-bit) real field addition subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_add_r32_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr
@@ -675,12 +683,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_0
+    end subroutine ccpp_field_add_r32_0
 
-    subroutine ccpp_fields_add_r32_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:)
@@ -688,12 +696,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_1
+    end subroutine ccpp_field_add_r32_1
 
-    subroutine ccpp_fields_add_r32_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:)
@@ -701,12 +709,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_2
+    end subroutine ccpp_field_add_r32_2
 
-    subroutine ccpp_fields_add_r32_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:,:)
@@ -714,12 +722,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_3
+    end subroutine ccpp_field_add_r32_3
 
-    subroutine ccpp_fields_add_r32_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:,:,:)
@@ -727,12 +735,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_4
+    end subroutine ccpp_field_add_r32_4
 
-    subroutine ccpp_fields_add_r32_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:,:,:,:)
@@ -740,12 +748,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_5
+    end subroutine ccpp_field_add_r32_5
 
-    subroutine ccpp_fields_add_r32_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:,:,:,:,:)
@@ -753,12 +761,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_6
+    end subroutine ccpp_field_add_r32_6
 
-    subroutine ccpp_fields_add_r32_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r32_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL32), target,   intent(in)    :: ptr(:,:,:,:,:,:,:)
@@ -766,17 +774,17 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r32_7
+    end subroutine ccpp_field_add_r32_7
 
     !------------------------------------------------------------------!
     !>
     !! Double precision (64-bit) real field addition subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_add_r64_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr
@@ -784,12 +792,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_0
+    end subroutine ccpp_field_add_r64_0
 
-    subroutine ccpp_fields_add_r64_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:)
@@ -797,12 +805,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_1
+    end subroutine ccpp_field_add_r64_1
 
-    subroutine ccpp_fields_add_r64_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:)
@@ -810,12 +818,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_2
+    end subroutine ccpp_field_add_r64_2
 
-    subroutine ccpp_fields_add_r64_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:,:)
@@ -823,12 +831,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_3
+    end subroutine ccpp_field_add_r64_3
 
-    subroutine ccpp_fields_add_r64_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:,:,:)
@@ -836,12 +844,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_4
+    end subroutine ccpp_field_add_r64_4
 
-    subroutine ccpp_fields_add_r64_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:,:,:,:)
@@ -849,12 +857,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_5
+    end subroutine ccpp_field_add_r64_5
 
-    subroutine ccpp_fields_add_r64_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:,:,:,:,:)
@@ -862,12 +870,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_6
+    end subroutine ccpp_field_add_r64_6
 
-    subroutine ccpp_fields_add_r64_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_r64_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         real(kind=REAL64), target,   intent(in)    :: ptr(:,:,:,:,:,:,:)
@@ -875,17 +883,17 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_r64_7
+    end subroutine ccpp_field_add_r64_7
 
     !------------------------------------------------------------------!
     !>
     !! Logical field addition subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_add_l_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr
@@ -893,12 +901,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_0
+    end subroutine ccpp_field_add_l_0
 
-    subroutine ccpp_fields_add_l_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:)
@@ -906,12 +914,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_1
+    end subroutine ccpp_field_add_l_1
 
-    subroutine ccpp_fields_add_l_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:)
@@ -919,12 +927,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_2
+    end subroutine ccpp_field_add_l_2
 
-    subroutine ccpp_fields_add_l_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:,:)
@@ -932,12 +940,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_3
+    end subroutine ccpp_field_add_l_3
 
-    subroutine ccpp_fields_add_l_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:,:,:)
@@ -945,12 +953,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_4
+    end subroutine ccpp_field_add_l_4
 
-    subroutine ccpp_fields_add_l_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:,:,:,:)
@@ -958,12 +966,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_5
+    end subroutine ccpp_field_add_l_5
 
-    subroutine ccpp_fields_add_l_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:,:,:,:,:)
@@ -971,12 +979,12 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_6
+    end subroutine ccpp_field_add_l_6
 
-    subroutine ccpp_fields_add_l_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_add_l_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                intent(inout) :: cdata
         character(len=*),            intent(in)    :: standard_name
         logical, target,             intent(in)    :: ptr(:,:,:,:,:,:,:)
@@ -984,17 +992,35 @@ module ccpp_fields
         character(len=*), optional,  intent(in)    :: units
 
         ierr = 0
-        call ccpp_fields_add_ptr(cdata, standard_name, units, &
-                                 c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), size(shape(ptr)), shape(ptr), ierr=ierr)
 
-    end subroutine ccpp_fields_add_l_7
+    end subroutine ccpp_field_add_l_7
+
+    !------------------------------------------------------------------!
+    !>
+    !! Character field addition subroutines.
+    !
+    !------------------------------------------------------------------!
+    subroutine ccpp_field_add_c_0(cdata, standard_name, ptr, ierr, units)
+        type(ccpp_t),                intent(inout) :: cdata
+        character(len=*),            intent(in)    :: standard_name
+        character(len=*), target,    intent(in)    :: ptr
+        integer,                     intent(  out) :: ierr
+        character(len=*), optional,  intent(in)    :: units
+
+        ierr = 0
+        call ccpp_field_add_ptr(cdata, standard_name, units, &
+                                c_loc(ptr), ierr=ierr)
+
+    end subroutine ccpp_field_add_c_0
 
     !------------------------------------------------------------------!
     !>
     !! Single precision (32-bit) integer field retrieval subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_get_i32_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr
@@ -1017,9 +1043,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_0
+    end subroutine ccpp_field_get_i32_0
 
-    subroutine ccpp_fields_get_i32_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:)
@@ -1042,9 +1068,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_1
+    end subroutine ccpp_field_get_i32_1
 
-    subroutine ccpp_fields_get_i32_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:)
@@ -1067,9 +1093,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_2
+    end subroutine ccpp_field_get_i32_2
 
-    subroutine ccpp_fields_get_i32_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:,:)
@@ -1092,9 +1118,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_3
+    end subroutine ccpp_field_get_i32_3
 
-    subroutine ccpp_fields_get_i32_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:,:,:)
@@ -1117,9 +1143,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_4
+    end subroutine ccpp_field_get_i32_4
 
-    subroutine ccpp_fields_get_i32_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:,:,:,:)
@@ -1142,9 +1168,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_5
+    end subroutine ccpp_field_get_i32_5
 
-    subroutine ccpp_fields_get_i32_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:,:,:,:,:)
@@ -1167,9 +1193,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_6
+    end subroutine ccpp_field_get_i32_6
 
-    subroutine ccpp_fields_get_i32_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i32_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT32), pointer, intent(  out) :: ptr(:,:,:,:,:,:,:)
@@ -1192,14 +1218,14 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i32_7
+    end subroutine ccpp_field_get_i32_7
 
     !------------------------------------------------------------------!
     !>
     !! Double precision (64-bit) integer field retrieval subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_get_i64_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr
@@ -1222,9 +1248,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_0
+    end subroutine ccpp_field_get_i64_0
 
-    subroutine ccpp_fields_get_i64_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:)
@@ -1247,9 +1273,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_1
+    end subroutine ccpp_field_get_i64_1
 
-    subroutine ccpp_fields_get_i64_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:)
@@ -1272,9 +1298,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_2
+    end subroutine ccpp_field_get_i64_2
 
-    subroutine ccpp_fields_get_i64_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:,:)
@@ -1297,9 +1323,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_3
+    end subroutine ccpp_field_get_i64_3
 
-    subroutine ccpp_fields_get_i64_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:,:,:)
@@ -1322,9 +1348,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_4
+    end subroutine ccpp_field_get_i64_4
 
-    subroutine ccpp_fields_get_i64_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:,:,:,:)
@@ -1347,9 +1373,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_5
+    end subroutine ccpp_field_get_i64_5
 
-    subroutine ccpp_fields_get_i64_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:,:,:,:,:)
@@ -1372,9 +1398,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_6
+    end subroutine ccpp_field_get_i64_6
 
-    subroutine ccpp_fields_get_i64_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_i64_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),                 intent(in)    :: cdata
         character(len=*),             intent(in)    :: standard_name
         integer(kind=INT64), pointer, intent(  out) :: ptr(:,:,:,:,:,:,:)
@@ -1397,14 +1423,14 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_i64_7
+    end subroutine ccpp_field_get_i64_7
 
     !------------------------------------------------------------------!
     !>
     !! Single precision (32-bit) real field retrieval subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_get_r32_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr
@@ -1427,9 +1453,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_0
+    end subroutine ccpp_field_get_r32_0
 
-    subroutine ccpp_fields_get_r32_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:)
@@ -1452,9 +1478,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_1
+    end subroutine ccpp_field_get_r32_1
 
-    subroutine ccpp_fields_get_r32_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:)
@@ -1477,9 +1503,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_2
+    end subroutine ccpp_field_get_r32_2
 
-    subroutine ccpp_fields_get_r32_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:,:)
@@ -1502,9 +1528,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_3
+    end subroutine ccpp_field_get_r32_3
 
-    subroutine ccpp_fields_get_r32_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:,:,:)
@@ -1527,9 +1553,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_4
+    end subroutine ccpp_field_get_r32_4
 
-    subroutine ccpp_fields_get_r32_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:,:,:,:)
@@ -1552,9 +1578,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_5
+    end subroutine ccpp_field_get_r32_5
 
-    subroutine ccpp_fields_get_r32_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:,:,:,:,:)
@@ -1577,9 +1603,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_6
+    end subroutine ccpp_field_get_r32_6
 
-    subroutine ccpp_fields_get_r32_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r32_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL32), pointer, intent(  out) :: ptr(:,:,:,:,:,:,:)
@@ -1602,14 +1628,14 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r32_7
+    end subroutine ccpp_field_get_r32_7
 
     !------------------------------------------------------------------!
     !>
     !! Double precision (64-bit) real field retrieval subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_get_r64_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr
@@ -1632,9 +1658,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_0
+    end subroutine ccpp_field_get_r64_0
 
-    subroutine ccpp_fields_get_r64_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:)
@@ -1657,9 +1683,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_1
+    end subroutine ccpp_field_get_r64_1
 
-    subroutine ccpp_fields_get_r64_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:)
@@ -1682,9 +1708,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_2
+    end subroutine ccpp_field_get_r64_2
 
-    subroutine ccpp_fields_get_r64_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:,:)
@@ -1707,9 +1733,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_3
+    end subroutine ccpp_field_get_r64_3
 
-    subroutine ccpp_fields_get_r64_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:,:,:)
@@ -1732,9 +1758,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_4
+    end subroutine ccpp_field_get_r64_4
 
-    subroutine ccpp_fields_get_r64_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:,:,:,:)
@@ -1757,9 +1783,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_5
+    end subroutine ccpp_field_get_r64_5
 
-    subroutine ccpp_fields_get_r64_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:,:,:,:,:)
@@ -1782,9 +1808,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_6
+    end subroutine ccpp_field_get_r64_6
 
-    subroutine ccpp_fields_get_r64_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_r64_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         real(kind=REAL64), pointer, intent(  out) :: ptr(:,:,:,:,:,:,:)
@@ -1807,14 +1833,14 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_r64_7
+    end subroutine ccpp_field_get_r64_7
 
     !------------------------------------------------------------------!
     !>
     !! Logical field retrieval subroutines.
     !
     !------------------------------------------------------------------!
-    subroutine ccpp_fields_get_l_0(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_0(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr
@@ -1837,9 +1863,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_0
+    end subroutine ccpp_field_get_l_0
 
-    subroutine ccpp_fields_get_l_1(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_1(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:)
@@ -1862,9 +1888,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_1
+    end subroutine ccpp_field_get_l_1
 
-    subroutine ccpp_fields_get_l_2(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_2(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:)
@@ -1887,9 +1913,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_2
+    end subroutine ccpp_field_get_l_2
 
-    subroutine ccpp_fields_get_l_3(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_3(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:,:)
@@ -1912,9 +1938,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_3
+    end subroutine ccpp_field_get_l_3
 
-    subroutine ccpp_fields_get_l_4(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_4(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:,:,:)
@@ -1937,9 +1963,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_4
+    end subroutine ccpp_field_get_l_4
 
-    subroutine ccpp_fields_get_l_5(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_5(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:,:,:,:)
@@ -1962,9 +1988,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_5
+    end subroutine ccpp_field_get_l_5
 
-    subroutine ccpp_fields_get_l_6(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_6(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:,:,:,:,:)
@@ -1987,9 +2013,9 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_6
+    end subroutine ccpp_field_get_l_6
 
-    subroutine ccpp_fields_get_l_7(cdata, standard_name, ptr, ierr, units)
+    subroutine ccpp_field_get_l_7(cdata, standard_name, ptr, ierr, units)
         type(ccpp_t),               intent(in)    :: cdata
         character(len=*),           intent(in)    :: standard_name
         logical, pointer,           intent(  out) :: ptr(:,:,:,:,:,:,:)
@@ -2012,7 +2038,38 @@ module ccpp_fields
             units = cdata%fields(idx)%units
         end if
 
-    end subroutine ccpp_fields_get_l_7
+    end subroutine ccpp_field_get_l_7
+
+    !------------------------------------------------------------------!
+    !>
+    !! Character field retrieval subroutines.
+    !
+    !------------------------------------------------------------------!
+    subroutine ccpp_field_get_c_0(cdata, standard_name, ptr, ierr, units)
+        type(ccpp_t),               intent(in)    :: cdata
+        character(len=*),           intent(in)    :: standard_name
+        character(len=*), pointer,  intent(  out) :: ptr
+        integer,                    intent(  out) :: ierr
+        character(len=*), optional, intent(  out) :: units
+
+        integer                                   :: idx
+
+        ierr = 0
+        ! Lookup the standard name in the index
+        idx = ccpp_fields_find(cdata, standard_name, ierr)
+        if (ierr /= 0) then
+            call ccpp_warn('Unable to find the requested field')
+            return
+        end if
+
+        call c_f_pointer(cdata%fields(idx)%ptr, ptr)
+
+        if (present(units)) then
+            units = cdata%fields(idx)%units
+        end if
+
+    end subroutine ccpp_field_get_c_0
+
     !------------------------------------------------------------------!
 
 end module ccpp_fields

--- a/src/ccpp_strings.F90
+++ b/src/ccpp_strings.F90
@@ -14,7 +14,7 @@
 !>
 !! @brief String routines module.
 !!
-!! @details A module continaing subroutines and fuctions to
+!! @details A module continaing subroutines and functions to
 !!          manipulate strings.
 !
 module ccpp_strings

--- a/src/tests/test_check.f90
+++ b/src/tests/test_check.f90
@@ -25,7 +25,7 @@ program test_check
     use            :: ccpp_fcall,                                      &
                       only: ccpp_run
     use            :: ccpp_fields,                                     &
-                      only: ccpp_fields_add
+                      only: ccpp_field_add
 
     implicit none
 
@@ -79,16 +79,16 @@ program test_check
     end if
 
     ! Add all the fields we want to expose to the physics driver.
-    call ccpp_fields_add(cdata, 'gravity', gravity, ierr, 'm s-2')
+    call ccpp_field_add(cdata, 'gravity', gravity, ierr, 'm s-2')
     if (ierr /= 0) then
             call exit(1)
     end if
 
-    call ccpp_fields_add(cdata, 'surface_temperature', surf_t, ierr, 'K')
+    call ccpp_field_add(cdata, 'surface_temperature', surf_t, ierr, 'K')
 
-    call ccpp_fields_add(cdata, 'eastward_wind', u, ierr, 'm s-1')
+    call ccpp_field_add(cdata, 'eastward_wind', u, ierr, 'm s-1')
 
-    call ccpp_fields_add(cdata, 'northward_wind', v, ierr, 'm s-1')
+    call ccpp_field_add(cdata, 'northward_wind', v, ierr, 'm s-1')
 
     call ccpp_run(cdata%suite%ipds(1)%subcycles(1)%schemes(1), cdata, ierr)
 


### PR DESCRIPTION
This PR performs cleanup work and adds support for correct error handling in physics schemes.

Cleanup work includes:
- renaming of metadata columns
- renaming of ccpp_fields_{add,get} to ccpp_field_{add,get}
- improvements to Python scripts
- formatting changes

Support for error handling in physics schemes includes:
- additional routines for storing and retrieving character(len=XYZ) variables in/from the cdata structure
- converting scheme caps into functions, returning an error code of type c_int32_t to the C interface
- an error code other than 0 forces CCPP to return immediately with the same error code to the host model

The changes have been tested for b4b identical results on Cheyenne and MacOSX systems. On Theia with Intel 18, the results are different because of a problem identified and rectified in https://github.com/NCAR/gmtb-gfsphysics/pull/47.

UPDATE 20180312: with the modifications in https://github.com/NCAR/gmtb-gfsphysics/pull/47, results are now bit for bit identical on all systems.