### PR TITLE
gmtb-ccpp optimization: speedup of ccpp init

### DIFF
--- a/scripts/mkcap.py
+++ b/scripts/mkcap.py
@@ -282,14 +282,16 @@ class Var(object):
 
     def print_add(self, ccpp_data_structure):
         '''Print the data addition line for the variable. Depends on the type of variable.
-        Since the name of the ccpp data structure is not known, this needs to be filled later.'''
+        Since the name of the ccpp data structure is not known, this needs to be filled later.
+        In case of errors a message is printed to screen; using 'return' statements as above
+        for ccpp_field_get is not possible, since the ccpp_field_add statements may be placed
+        inside OpenMP parallel regions.'''
         # Standard-type variables, scalar and array
         if self.type in STANDARD_VARIABLE_TYPES:
             str='''
             call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', {s.target}, ierr, '{s.units}')
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
-                return
             end if'''
         # Derived-type variables, scalar
         elif self.rank == '':
@@ -297,7 +299,6 @@ class Var(object):
             call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), ierr)
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
-                return
             end if'''
         # Derived-type variables, array
         else:
@@ -305,7 +306,6 @@ class Var(object):
             call ccpp_field_add({ccpp_data_structure}, '{s.standard_name}', '', c_loc({s.target}), rank=size(shape({s.target})), dims=shape({s.target}), ierr=ierr)
             if (ierr /= 0) then
                 call ccpp_error('Unable to add field "{s.standard_name}" to CCPP data structure')
-                return
             end if'''
         return str.format(ccpp_data_structure=ccpp_data_structure, s=self)
 

--- a/src/ccpp.F90
+++ b/src/ccpp.F90
@@ -20,7 +20,7 @@ module ccpp
     use, intrinsic :: iso_c_binding,                                   &
                       only: c_ptr
     use            :: ccpp_types,                                      &
-                      only: ccpp_t
+                      only: ccpp_t, ccpp_suite_t
     use            :: ccpp_suite,                                      &
                       only: ccpp_suite_init, ccpp_suite_finalize
     use            :: ccpp_fields,                                     &
@@ -43,20 +43,26 @@ module ccpp
     !! @param[in,out] cdata    The ccpp_t type data.
     !! @param[  out]  ierr     Integer error flag.
     !
-    subroutine ccpp_init(filename, cdata, ierr)
-        character(len=*),       intent(in)    :: filename
-        type(ccpp_t),           intent(inout) :: cdata
-        integer,                intent(  out) :: ierr
+    subroutine ccpp_init(filename, cdata, ierr, suite)
+        character(len=*),   intent(in)           :: filename
+        type(ccpp_t),       intent(inout)        :: cdata
+        integer,            intent(  out)        :: ierr
+        type(ccpp_suite_t), intent(in), optional :: suite
 
         ierr = 0
 
         !call ccpp_debug('Called ccpp_init')
 
-        ! Initialize the suite
-        call ccpp_suite_init(filename, cdata%suite, ierr)
-        if (ierr /= 0) then
-            call ccpp_error('In initializing the CCPP suite')
-            return
+        if (present(suite)) then
+            cdata%suite = suite
+            cdata%suite%iscopy = .True.
+        else
+            ! Initialize the suite
+            call ccpp_suite_init(filename, cdata%suite, ierr)
+            if (ierr /= 0) then
+                call ccpp_error('In initializing the CCPP suite')
+                return
+            end if
         end if
 
         ! Initialize the fields

--- a/src/ccpp_fields_idx.c
+++ b/src/ccpp_fields_idx.c
@@ -88,8 +88,7 @@ ccpp_field_idx_init(void **index)
 	f_index->sorted = 0;
 	f_index->n      = 0;
 	f_index->max    = CCPP_FIELD_IDX_MAX;
-	f_index->fields = malloc(CCPP_FIELD_IDX_MAX *
-				 sizeof(struct ccpp_field *));
+	f_index->fields = malloc(CCPP_FIELD_IDX_MAX * sizeof(struct ccpp_field *));
 
 	return(EXIT_SUCCESS);
 }
@@ -200,7 +199,7 @@ ccpp_field_idx_find(const char *name, void **index)
 	key->name[n] = '\0';
 
 	res = bsearch(&key, f_index->fields, f_index->n,
-		      sizeof(struct ccpp_field *), cmp);
+		          sizeof(struct ccpp_field *), cmp);
 	if (*res == NULL) {
 		warnx("Unable to find in index: %s", name);
 		return(-1);
@@ -240,6 +239,9 @@ ccpp_field_idx_sort(void **index)
 static int
 ccpp_field_idx_grow(void **index)
 {
+	// Warn user that field index array needs to grow
+	warnx("Growing field index array");
+
 	struct ccpp_field_idx *f_index;
 	struct ccpp_field **new;
 	int new_max;

--- a/src/ccpp_fields_idx.h
+++ b/src/ccpp_fields_idx.h
@@ -29,8 +29,8 @@ extern "C"
 #endif
 
 
-#define  CCPP_FIELD_IDX_MAX     75
-#define  CCPP_FIELD_IDX_GROW    1.75
+#define  CCPP_FIELD_IDX_MAX     500 // was 75
+#define  CCPP_FIELD_IDX_GROW    2   // was 1.75
 
 
 struct ccpp_field {

--- a/src/ccpp_suite.F90
+++ b/src/ccpp_suite.F90
@@ -200,6 +200,9 @@ module ccpp_suite
         ierr = ccpp_xml_unload(xml)
         call ccpp_suite_load(suite, ierr)
 
+        ! Set flag indicating that this suite is not a copy of another suite
+        suite%iscopy = .False.
+
     end subroutine ccpp_suite_init
 
     !>
@@ -220,7 +223,9 @@ module ccpp_suite
 
         !call ccpp_debug('Called ccpp_suite_finalize')
 
-        call ccpp_suite_unload(suite, ierr)
+        if (.not.suite%iscopy) then
+            call ccpp_suite_unload(suite, ierr)
+        end if
 
         do i=1, suite%ipds_max
             do j=1, suite%ipds(i)%subcycles_max

--- a/src/ccpp_types.F90
+++ b/src/ccpp_types.F90
@@ -109,6 +109,7 @@ module ccpp_types
             integer                                             :: ipds_max
             integer                                             :: ipd_n
             type(ccpp_ipd_t), allocatable, dimension(:)         :: ipds
+            logical                                             :: iscopy
     end type ccpp_suite_t
 
     !>


### PR DESCRIPTION
This PR improves the performance of the CCPP implementation in FV3 v0 by

- making use of threading (i.e. OpenMP parallel regions) where possible
- by adding functionality to the CCPP infrastructure that allows to copy an existing CCPP suite data structure from one cdata structure to another. An additional attribute iscopy is required for the CCPP suite data structure to distinguish between the original suite data type and its copy because of C-pointer types being used inside the data structure
- and by increasing the default size of the cdata field index array from 75 to 500 (currently about 400 fields are used in FV3)

The results are bit for bit compatible (tested on Theia/Intel and Macbook/GNU with OpenMP enabled).