### PR TITLE
Scm integration fv3mods dom

### DIFF
--- a/cmake/FindOpenMP_Fortran.cmake
+++ b/cmake/FindOpenMP_Fortran.cmake
@@ -32,9 +32,9 @@ SET (OpenMP_Fortran_FLAG_CANDIDATES
      #Microsoft Visual Studio
      "/openmp"
      #Intel windows
-     "/Qopenmp" 
+     "/Qopenmp"
      #Intel
-     "-openmp" 
+     "-qopenmp"
      #Gnu
      "-fopenmp"
      #Empty, if compiler automatically accepts openmp

--- a/schemes/CMakeLists.txt
+++ b/schemes/CMakeLists.txt
@@ -19,17 +19,3 @@ ExternalProject_Add(
                -DCCPP_MKCAP=${CMAKE_CURRENT_SOURCE_DIR}/mkcap.py
 )
 
-#------------------------------------------------------------------------------
-# The dummy SCM scheme
-#ExternalProject_Add(
-#    scm
-#    DEPENDS ccpp
-#    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scm"
-#    PREFIX "scm"
-#    DOWNLOAD_COMMAND  ""
-#    UPDATE_COMMAND    ""
-#    INSTALL_COMMAND   ""
-#    CMAKE_ARGS -DCCPP_INCLUDE_DIRS=${CCPP_INCLUDE_DIRS}
-#               -DCCPP_LIB_DIRS=${CCPP_LIB_DIRS}
-#               -DCCPP_MKCAP=${CMAKE_CURRENT_SOURCE_DIR}/mkcap.py
-#)

--- a/scripts/ccpp_prebuild.py
+++ b/scripts/ccpp_prebuild.py
@@ -24,138 +24,45 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--debug', action='store_true', help = 'enable debugging output', default=False)
 
 ###############################################################################
-# Definitions                                                                 #
+# User definitions                                                            #
 ###############################################################################
 
+# Define host model (only parameter to set in this file)
+#HOST_MODEL = "SCM"
+HOST_MODEL = "FV3"
+
+# No further modifications should be required below,
+# all other parameters are set in ccpp_prebuild_config_HOST_MODEL.py
+
+###############################################################################
+# Definitions (imported)                                                      #
+###############################################################################
+
+# basedir is the current directory where this script is executed
 basedir = os.getcwd()
 
-# Relative to basedir
-variable_definition_files = [
-    '../../gmtb-scm/src/gmtb_scm_type_defs.f90',
-    '../../gmtb-scm/src/gmtb_scm_physical_constants.f90'
-    #'../schemes/gfsphysics/physics/physcons.f90',
-    ]
+# Import the host-model specific CCPP prebuild config
+ccpp_prebuild_config_name = "ccpp_prebuild_config_{0}".format(HOST_MODEL)
+ccpp_prebuild_config = __import__(ccpp_prebuild_config_name)
 
-# Location of scheme_files relative to basedir
-scheme_files = [
-    '../../gmtb-gfsphysics/GFS_layer/GFS_initialize_scm.F90',
-    '../../gmtb-gfsphysics/physics/GFS_phys_time_vary.f90',
-    '../../gmtb-gfsphysics/physics/GFS_rad_time_vary.f90',
-    '../../gmtb-gfsphysics/physics/GFS_suite_interstitial.ccpp.f90',
-    '../../gmtb-gfsphysics/physics/GFS_rrtmg_pre.F90',
-    '../../gmtb-gfsphysics/physics/rrtmg_sw_pre.F90',
-    '../../gmtb-gfsphysics/physics/radsw_main.f',
-    '../../gmtb-gfsphysics/physics/rrtmg_sw_post.F90',
-    '../../gmtb-gfsphysics/physics/rrtmg_lw_pre.F90',
-    '../../gmtb-gfsphysics/physics/radlw_main.f',
-    '../../gmtb-gfsphysics/physics/rrtmg_lw_post.F90',
-    '../../gmtb-gfsphysics/physics/GFS_rrtmg_post.F90',
-    '../../gmtb-gfsphysics/physics/get_prs_fv3.f90',
-    '../../gmtb-gfsphysics/physics/sfc_sice.f',
-    '../../gmtb-gfsphysics/physics/dcyc2.f',
-    '../../gmtb-gfsphysics/physics/GFS_surface_generic.f90',
-    '../../gmtb-gfsphysics/physics/GFS_PBL_generic.f90',
-    '../../gmtb-gfsphysics/physics/sfc_drv.f',
-    '../../gmtb-gfsphysics/physics/sfc_diff.f',
-    '../../gmtb-gfsphysics/physics/GFS_surface_loop_control.f',
-    '../../gmtb-gfsphysics/physics/sfc_nst.f',
-    '../../gmtb-gfsphysics/physics/sfc_diag.f',
-    '../../gmtb-gfsphysics/physics/moninedmf.f',
-    '../../gmtb-gfsphysics/physics/gwdps.f',
-    '../../gmtb-gfsphysics/physics/rayleigh_damp.f',
-    '../../gmtb-gfsphysics/physics/ozphys.f',
-    '../../gmtb-gfsphysics/physics/GFS_DCNV_generic.f90',
-    '../../gmtb-gfsphysics/physics/GFS_zhao_carr_pre.f90',
-    '../../gmtb-gfsphysics/physics/mfdeepcnv.f',
-    '../../gmtb-gfsphysics/physics/gwdc.f',
-    '../../gmtb-gfsphysics/physics/GFS_SCNV_generic.f90',
-    '../../gmtb-gfsphysics/physics/mfshalcnv.f',
-    '../../gmtb-gfsphysics/physics/cnvc90.f',
-    '../../gmtb-gfsphysics/physics/GFS_MP_generic_pre.f90',
-    '../../gmtb-gfsphysics/physics/gscond.f',
-    '../../gmtb-gfsphysics/physics/precpd.f',
-    '../../gmtb-gfsphysics/physics/GFS_calpreciptype.f90',
-    '../../gmtb-gfsphysics/physics/GFS_MP_generic_post.f90',
-    ]
-
-# Relative to basedir
-schemes_makefile = '../../gmtb-gfsphysics/CCPP_SCHEMES.mk'
-
-# Relative to basedir
-target_files = [
-    '../../gmtb-scm/src/gmtb_scm.f90',
-    ]
-
-# Relative to basedir
-caps_makefile = '../../gmtb-gfsphysics/CCPP_CAPS.mk'
-caps_dir = '../../gmtb-gfsphysics/physics'
-
-# Optional arguments - only required for schemes that use optional arguments. This script will throw
-# an exception if it encounters a scheme subroutine with optional arguments if no entry is made in
-# the following dictionary. Valid values are 'all', 'none' or a list of arguments: [ 'var1', 'var3' ].
-optional_arguments = {
-    'rrtmg_sw' : {
-        'rrtmg_sw_run' : [
-            'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
-            'components_of_surface_downward_shortwave_fluxes',
-            'cloud_liquid_water_path',
-            'mean_effective_radius_for_liquid_cloud',
-            'cloud_ice_water_path',
-            'mean_effective_radius_for_ice_cloud',
-            'cloud_rain_water_path',
-            'mean_effective_radius_for_rain_drop',
-            'cloud_snow_water_path',
-            'mean_effective_radius_for_snow_flake',
-            ],
-        },
-    'rrtmg_lw' : {
-        'rrtmg_lw_run' : [
-            'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
-            'cloud_liquid_water_path',
-            'mean_effective_radius_for_liquid_cloud',
-            'cloud_ice_water_path',
-            'mean_effective_radius_for_ice_cloud',
-            'cloud_rain_water_path',
-            'mean_effective_radius_for_rain_drop',
-            'cloud_snow_water_path',
-            'mean_effective_radius_for_snow_flake',
-            ],
-        },
-    #'subroutine_name_1' : 'all',
-    #'subroutine_name_2' : 'none',
-    #'subroutine_name_2' : [ 'var1', 'var3'],
-    }
-
-# No path needed - will be created in directory of target files defined above
-module_include_file = 'ccpp_modules.inc'
-fields_include_file = 'ccpp_fields.inc'
+# Definitions in host-model dependent CCPP prebuild config script
+variable_definition_files = ccpp_prebuild_config.VARIABLE_DEFINITION_FILES
+scheme_files              = ccpp_prebuild_config.SCHEME_FILES
+schemes_makefile          = ccpp_prebuild_config.SCHEMES_MAKEFILE
+target_files              = ccpp_prebuild_config.TARGET_FILES
+caps_makefile             = ccpp_prebuild_config.CAPS_MAKEFILE
+caps_dir                  = ccpp_prebuild_config.CAPS_DIR
+optional_arguments        = ccpp_prebuild_config.OPTIONAL_ARGUMENTS
+module_include_file       = ccpp_prebuild_config.MODULE_INCLUDE_FILE
+fields_include_file       = ccpp_prebuild_config.FIELDS_INCLUDE_FILE
 
 ###############################################################################
-# Template code to generate include files                                     #
+# Template code to generate include files (imported)                          #
 ###############################################################################
 
-# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
-MODULE_USE_TEMPLATE_HOST_CAP = \
-'''
-use ccpp_errors, only: ccpp_error
-'''
-
-CCPP_DATA_STRUCTURE = 'cdata(i)'
-
-# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
-MODULE_USE_TEMPLATE_SCHEME_CAP = \
-'''
-       use machine, only: kind_phys
-       use module_radlw_parameters, only: sfcflw_type, topflw_type
-       use module_radsw_parameters, only: cmpfsw_type, sfcfsw_type, topfsw_type
-       use GFS_typedefs, only: GFS_statein_type,  GFS_stateout_type,    &
-                               GFS_sfcprop_type,  GFS_sfccycle_type,    &
-                               GFS_coupling_type, GFS_control_type,     &
-                               GFS_grid_type,     GFS_tbd_type,         &
-                               GFS_cldprop_type,  GFS_radtend_type,     &
-                               GFS_diag_type,     GFS_interstitial_type,&
-                               GFS_init_type
-'''
+module_use_template_host_cap   = ccpp_prebuild_config.MODULE_USE_TEMPLATE_HOST_CAP
+ccpp_data_structure            = ccpp_prebuild_config.CCPP_DATA_STRUCTURE
+module_use_template_scheme_cap = ccpp_prebuild_config.MODULE_USE_TEMPLATE_SCHEME_CAP
 
 ###############################################################################
 # Functions and subroutines                                                   #
@@ -332,11 +239,11 @@ def compare_metadata(metadata_define, metadata_request):
     return (success, modules, metadata)
 
 def create_module_use_statements(modules):
-    # MODULE_USE_TEMPLATE_HOST_CAP must include the required modules
+    # module_use_template_host_cap must include the required modules
     # for error handling of the ccpp_field_add statments
     logging.info('Generating module use statements ...')
     success = True
-    module_use_statements = MODULE_USE_TEMPLATE_HOST_CAP
+    module_use_statements = module_use_template_host_cap
     cnt = 1
     for module in modules:
         module_use_statements += 'use {0}\n'.format(module)
@@ -358,7 +265,7 @@ def create_ccpp_field_add_statements(metadata):
     for var_name in sorted(metadata.keys()):
         # Add variable with var_name = standard_name once
         var = metadata[var_name][0]
-        ccpp_field_add_statements += var.print_add(CCPP_DATA_STRUCTURE)
+        ccpp_field_add_statements += var.print_add(ccpp_data_structure)
         cnt += 1
     logging.info('Generated ccpp_field_add statements for {0} variable(s)'.format(cnt))
     return (success, ccpp_field_add_statements)
@@ -409,8 +316,8 @@ def generate_scheme_caps(metadata, arguments):
                         if var.container == container:
                             capdata[subroutine_name].append(var)
                             break
-            # If required (not at the moment), add module use statements to MODULE_USE_TEMPLATE_SCHEME_CAP
-            module_use_statement = MODULE_USE_TEMPLATE_SCHEME_CAP
+            # If required (not at the moment), add module use statements to module_use_template_scheme_cap
+            module_use_statement = module_use_template_scheme_cap
             # Write cap
             cap.write(module_name, module_use_statement, capdata)
     #

--- a/scripts/ccpp_prebuild_config_FV3.py
+++ b/scripts/ccpp_prebuild_config_FV3.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+# CCPP prebuild config for GFDL Finite-Volume Cubed-Sphere Model (FV3) v0.0
+
+
+###############################################################################
+# Definitions                                                                 #
+###############################################################################
+
+# Relative to basedir defined in ccpp_prebuild.py
+VARIABLE_DEFINITION_FILES = [
+    'FV3/gfsphysics/GFS_layer/GFS_typedefs.F90',
+    'FV3/gfsphysics/physics/physcons.f90',
+    ]
+
+# Location of scheme_files relative to basedir defined in ccpp_prebuild.py
+SCHEME_FILES = [
+    'FV3/gfsphysics/physics/GFS_DCNV_generic.f90',
+    'FV3/gfsphysics/physics/GFS_MP_generic_post.f90',
+    'FV3/gfsphysics/physics/GFS_MP_generic_pre.f90',
+    'FV3/gfsphysics/physics/GFS_PBL_generic.f90',
+    'FV3/gfsphysics/physics/GFS_SCNV_generic.f90',
+    'FV3/gfsphysics/physics/GFS_calpreciptype.f90',
+    'FV3/gfsphysics/physics/GFS_debug.f90',
+    'FV3/gfsphysics/physics/GFS_phys_time_vary.f90',
+    'FV3/gfsphysics/physics/GFS_rad_time_vary.f90',
+    'FV3/gfsphysics/physics/GFS_rrtmg_post.F90',
+    'FV3/gfsphysics/physics/GFS_rrtmg_pre.F90',
+    'FV3/gfsphysics/physics/GFS_stochastics.f90',
+    'FV3/gfsphysics/physics/GFS_suite_interstitial.ccpp.f90',
+    'FV3/gfsphysics/physics/GFS_surface_generic.f90',
+    'FV3/gfsphysics/physics/GFS_surface_loop_control.f',
+    'FV3/gfsphysics/physics/GFS_zhao_carr_pre.f90',
+    'FV3/gfsphysics/physics/cnvc90.f',
+    'FV3/gfsphysics/physics/dcyc2.f',
+    'FV3/gfsphysics/physics/get_prs_fv3.f90',
+    'FV3/gfsphysics/physics/gscond.f',
+    'FV3/gfsphysics/physics/gwdc.f',
+    'FV3/gfsphysics/physics/gwdps.f',
+    'FV3/gfsphysics/physics/mfdeepcnv.f',
+    'FV3/gfsphysics/physics/mfshalcnv.f',
+    'FV3/gfsphysics/physics/moninedmf.f',
+    'FV3/gfsphysics/physics/ozphys.f',
+    'FV3/gfsphysics/physics/precpd.f',
+    'FV3/gfsphysics/physics/radlw_main.f',
+    'FV3/gfsphysics/physics/radsw_main.f',
+    'FV3/gfsphysics/physics/rayleigh_damp.f',
+    'FV3/gfsphysics/physics/rrtmg_lw_post.F90',
+    'FV3/gfsphysics/physics/rrtmg_lw_pre.F90',
+    'FV3/gfsphysics/physics/rrtmg_sw_post.F90',
+    'FV3/gfsphysics/physics/rrtmg_sw_pre.F90',
+    'FV3/gfsphysics/physics/sfc_diag.f',
+    'FV3/gfsphysics/physics/sfc_diff.f',
+    'FV3/gfsphysics/physics/sfc_drv.f',
+    'FV3/gfsphysics/physics/sfc_nst.f',
+    'FV3/gfsphysics/physics/sfc_sice.f',
+    ]
+
+# Relative to basedir defined in ccpp_prebuild.py
+SCHEMES_MAKEFILE = 'FV3/gfsphysics/CCPP_SCHEMES.mk'
+
+# Relative to basedir defined in ccpp_prebuild.py
+TARGET_FILES = [
+    'FV3/gfsphysics/IPD_layer/IPD_CCPP_Driver.F90',
+    ]
+
+# Relative to basedir
+CAPS_MAKEFILE = 'FV3/gfsphysics/CCPP_CAPS.mk'
+CAPS_DIR = 'FV3/gfsphysics/physics'
+
+# Optional arguments - only required for schemes that use optional arguments. This script will throw
+# an exception if it encounters a scheme subroutine with optional arguments if no entry is made in
+# the following dictionary. Valid values are 'all', 'none' or a list of arguments: [ 'var1', 'var3' ].
+OPTIONAL_ARGUMENTS = {
+    'rrtmg_sw' : {
+        'rrtmg_sw_run' : [
+            'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
+            'components_of_surface_downward_shortwave_fluxes',
+            'cloud_liquid_water_path',
+            'mean_effective_radius_for_liquid_cloud',
+            'cloud_ice_water_path',
+            'mean_effective_radius_for_ice_cloud',
+            'cloud_rain_water_path',
+            'mean_effective_radius_for_rain_drop',
+            'cloud_snow_water_path',
+            'mean_effective_radius_for_snow_flake',
+            ],
+        },
+    'rrtmg_lw' : {
+        'rrtmg_lw_run' : [
+            'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
+            'cloud_liquid_water_path',
+            'mean_effective_radius_for_liquid_cloud',
+            'cloud_ice_water_path',
+            'mean_effective_radius_for_ice_cloud',
+            'cloud_rain_water_path',
+            'mean_effective_radius_for_rain_drop',
+            'cloud_snow_water_path',
+            'mean_effective_radius_for_snow_flake',
+            ],
+        },
+    #'subroutine_name_1' : 'all',
+    #'subroutine_name_2' : 'none',
+    #'subroutine_name_2' : [ 'var1', 'var3'],
+    }
+
+# No path needed - will be created in directory of target files defined above
+MODULE_INCLUDE_FILE = 'ccpp_modules.inc'
+FIELDS_INCLUDE_FILE = 'ccpp_fields.inc'
+
+
+###############################################################################
+# Template code to generate include files                                     #
+###############################################################################
+
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
+MODULE_USE_TEMPLATE_HOST_CAP = \
+'''
+use ccpp_errors, only: ccpp_error
+'''
+
+# Name of the CCPP data structure in the host model cap
+CCPP_DATA_STRUCTURE = 'cdata_block(nb,nt)'
+
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
+MODULE_USE_TEMPLATE_SCHEME_CAP = \
+'''
+       use machine, only: kind_phys
+       use module_radlw_parameters, only: sfcflw_type, topflw_type
+       use module_radsw_parameters, only: cmpfsw_type, sfcfsw_type, topfsw_type
+       use GFS_typedefs, only: GFS_statein_type,  GFS_stateout_type,    &
+                               GFS_sfcprop_type,  GFS_sfccycle_type,    &
+                               GFS_coupling_type, GFS_control_type,     &
+                               GFS_grid_type,     GFS_tbd_type,         &
+                               GFS_cldprop_type,  GFS_radtend_type,     &
+                               GFS_diag_type,     GFS_interstitial_type
+'''

--- a/scripts/ccpp_prebuild_config_SCM.py
+++ b/scripts/ccpp_prebuild_config_SCM.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+# CCPP prebuild config for GMTB Single Column Model (SCM) v2.0
+
+
+###############################################################################
+# Definitions                                                                 #
+###############################################################################
+
+# Relative to basedir defined in ccpp_prebuild.py
+VARIABLE_DEFINITION_FILES = [
+    '../../gmtb-scm/src/gmtb_scm_type_defs.f90',
+    '../../gmtb-scm/src/gmtb_scm_physical_constants.f90'
+    ]
+
+# Location of scheme_files relative to basedir defined in ccpp_prebuild.py
+SCHEME_FILES = [
+    '../../gmtb-gfsphysics/GFS_layer/GFS_initialize_scm.F90',
+    '../../gmtb-gfsphysics/physics/GFS_DCNV_generic.f90',
+    '../../gmtb-gfsphysics/physics/GFS_MP_generic_post.f90',
+    '../../gmtb-gfsphysics/physics/GFS_MP_generic_pre.f90',
+    '../../gmtb-gfsphysics/physics/GFS_PBL_generic.f90',
+    '../../gmtb-gfsphysics/physics/GFS_SCNV_generic.f90',
+    '../../gmtb-gfsphysics/physics/GFS_calpreciptype.f90',
+    '../../gmtb-gfsphysics/physics/GFS_phys_time_vary.f90',
+    '../../gmtb-gfsphysics/physics/GFS_rad_time_vary.f90',
+    '../../gmtb-gfsphysics/physics/GFS_rrtmg_post.F90',
+    '../../gmtb-gfsphysics/physics/GFS_rrtmg_pre.F90',
+    '../../gmtb-gfsphysics/physics/GFS_suite_interstitial.ccpp.f90',
+    '../../gmtb-gfsphysics/physics/GFS_surface_generic.f90',
+    '../../gmtb-gfsphysics/physics/GFS_surface_loop_control.f',
+    '../../gmtb-gfsphysics/physics/GFS_zhao_carr_pre.f90',
+    '../../gmtb-gfsphysics/physics/cnvc90.f',
+    '../../gmtb-gfsphysics/physics/dcyc2.f',
+    '../../gmtb-gfsphysics/physics/get_prs_fv3.f90',
+    '../../gmtb-gfsphysics/physics/gscond.f',
+    '../../gmtb-gfsphysics/physics/gwdc.f',
+    '../../gmtb-gfsphysics/physics/gwdps.f',
+    '../../gmtb-gfsphysics/physics/mfdeepcnv.f',
+    '../../gmtb-gfsphysics/physics/mfshalcnv.f',
+    '../../gmtb-gfsphysics/physics/moninedmf.f',
+    '../../gmtb-gfsphysics/physics/ozphys.f',
+    '../../gmtb-gfsphysics/physics/precpd.f',
+    '../../gmtb-gfsphysics/physics/radlw_main.f',
+    '../../gmtb-gfsphysics/physics/radsw_main.f',
+    '../../gmtb-gfsphysics/physics/rayleigh_damp.f',
+    '../../gmtb-gfsphysics/physics/rrtmg_lw_post.F90',
+    '../../gmtb-gfsphysics/physics/rrtmg_lw_pre.F90',
+    '../../gmtb-gfsphysics/physics/rrtmg_sw_post.F90',
+    '../../gmtb-gfsphysics/physics/rrtmg_sw_pre.F90',
+    '../../gmtb-gfsphysics/physics/sfc_diag.f',
+    '../../gmtb-gfsphysics/physics/sfc_diff.f',
+    '../../gmtb-gfsphysics/physics/sfc_drv.f',
+    '../../gmtb-gfsphysics/physics/sfc_nst.f',
+    '../../gmtb-gfsphysics/physics/sfc_sice.f',
+    ]
+
+# Relative to basedir defined in ccpp_prebuild.py
+SCHEMES_MAKEFILE = '../../gmtb-gfsphysics/CCPP_SCHEMES.mk'
+
+# Relative to basedir defined in ccpp_prebuild.py
+TARGET_FILES = [
+    '../../gmtb-scm/src/gmtb_scm.f90',
+    ]
+
+# Relative to basedir defined in ccpp_prebuild.py
+CAPS_MAKEFILE = '../../gmtb-gfsphysics/CCPP_CAPS.mk'
+CAPS_DIR = '../../gmtb-gfsphysics/physics'
+
+# Optional arguments - only required for schemes that use optional arguments. This script will throw
+# an exception if it encounters a scheme subroutine with optional arguments if no entry is made in
+# the following dictionary. Valid values are 'all', 'none' or a list of arguments: [ 'var1', 'var3' ].
+OPTIONAL_ARGUMENTS = {
+    'rrtmg_sw' : {
+        'rrtmg_sw_run' : [
+            'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
+            'components_of_surface_downward_shortwave_fluxes',
+            'cloud_liquid_water_path',
+            'mean_effective_radius_for_liquid_cloud',
+            'cloud_ice_water_path',
+            'mean_effective_radius_for_ice_cloud',
+            'cloud_rain_water_path',
+            'mean_effective_radius_for_rain_drop',
+            'cloud_snow_water_path',
+            'mean_effective_radius_for_snow_flake',
+            ],
+        },
+    'rrtmg_lw' : {
+        'rrtmg_lw_run' : [
+            'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
+            'cloud_liquid_water_path',
+            'mean_effective_radius_for_liquid_cloud',
+            'cloud_ice_water_path',
+            'mean_effective_radius_for_ice_cloud',
+            'cloud_rain_water_path',
+            'mean_effective_radius_for_rain_drop',
+            'cloud_snow_water_path',
+            'mean_effective_radius_for_snow_flake',
+            ],
+        },
+    #'subroutine_name_1' : 'all',
+    #'subroutine_name_2' : 'none',
+    #'subroutine_name_2' : [ 'var1', 'var3'],
+    }
+
+# No path needed - will be created in directory of target files defined above
+MODULE_INCLUDE_FILE = 'ccpp_modules.inc'
+FIELDS_INCLUDE_FILE = 'ccpp_fields.inc'
+
+
+###############################################################################
+# Template code to generate include files                                     #
+###############################################################################
+
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
+MODULE_USE_TEMPLATE_HOST_CAP = \
+'''
+use ccpp_errors, only: ccpp_error
+'''
+
+# Name of the CCPP data structure in the host model cap
+CCPP_DATA_STRUCTURE = 'cdata(i)' 
+
+# Modules to load for auto-generated ccpp_field_add code (e.g. error handling)
+MODULE_USE_TEMPLATE_SCHEME_CAP = \
+'''
+       use machine, only: kind_phys
+       use module_radlw_parameters, only: sfcflw_type, topflw_type
+       use module_radsw_parameters, only: cmpfsw_type, sfcfsw_type, topfsw_type
+       use GFS_typedefs, only: GFS_statein_type,  GFS_stateout_type,    &
+                               GFS_sfcprop_type,  GFS_sfccycle_type,    &
+                               GFS_coupling_type, GFS_control_type,     &
+                               GFS_grid_type,     GFS_tbd_type,         &
+                               GFS_cldprop_type,  GFS_radtend_type,     &
+                               GFS_diag_type,     GFS_interstitial_type,&
+                               GFS_init_type
+'''


### PR DESCRIPTION
This PR adds additional logic to handle different host models in the CCPP prebuild script:

- import Python module containing CCPP prebuild config based on variable HOST_MODEL set in ccpp_prebuild.py
- two configurations ccpp_prebuild_config_SCM.py and ccpp_prebuild_config_FV3.py

Also included are fixes for deprecated OpenMP compiler flags for the Intel compiler and the removal of unused code.